### PR TITLE
Extract sidebar voice drawer component and inline expanded voice controls

### DIFF
--- a/packages/shared/src/client/app/ChatApp.tsx
+++ b/packages/shared/src/client/app/ChatApp.tsx
@@ -11,9 +11,9 @@ import { ServerSettingsModal } from '@shared/components/ServerSettingsModal';
 import { ChannelSettingsModal } from '@shared/components/ChannelSettingsModal';
 import { Sidebar } from '@shared/components/Sidebar';
 import { ChatArea } from '@shared/components/ChatArea';
-import { VoiceChannelPane } from '@shared/components/VoiceChannelPane';
 import { VoiceHardwareDebugPanel } from '@shared/components/VoiceHardwareDebugPanel';
 import { VoiceSettingsModal } from '@shared/components/VoiceSettingsModal';
+import { VoiceDrawer } from '@shared/components/voice/VoiceDrawer';
 import { NotificationCenterModal } from '@shared/components/NotificationCenterModal';
 import { FriendsModal } from '@shared/components/FriendsModal';
 import { DirectMessagesSidebar } from '@shared/components/DirectMessagesSidebar';
@@ -45,7 +45,6 @@ import {
   buildWebPushCutoverReadiness,
   buildWebPushQueueHealthAlerts,
 } from '@shared/lib/notifications/webPushDiagnostics';
-import { Headphones, Mic, MicOff, PhoneOff, Settings2, VolumeX } from 'lucide-react';
 import { toast } from 'sonner';
 import { useServerOrder } from '@client/features/community/hooks/useServerOrder';
 
@@ -199,117 +198,40 @@ export function ChatApp() {
               voiceChannelParticipants={app.voiceChannelParticipants}
               voiceStatusPanel={
                 app.activeVoiceChannel ? (
-                  <div className="px-2 pt-2 pb-1 border-b border-[#22334f]">
-                    <div className="rounded-md border border-[#304867] bg-[#142033] px-2 py-2 space-y-2">
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0">
-                          <p className="text-[11px] uppercase tracking-wide text-[#8ea4c7]">Voice Connected</p>
-                          <p className="text-xs font-semibold text-white truncate flex items-center gap-1">
-                            <Headphones className="size-3.5" />
-                            {app.activeVoiceChannel.name}
-                          </p>
-                          <p className="text-[11px] text-[#95a5bf] truncate">{app.currentServer.name}</p>
-                        </div>
-                        <span
-                          className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
-                            app.voiceConnected
-                              ? 'bg-[#2f9f73]/20 text-[#6dd5a6]'
-                              : 'bg-[#44546f]/40 text-[#b5c4de]'
-                          }`}
-                        >
-                          {app.voiceConnected ? 'Live' : 'Connecting'}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        {!app.voiceSessionState.joined ? (
-                          <Button
-                            type="button"
-                            size="icon-xs"
-                            variant="ghost"
-                            onClick={() => app.voiceControlActions?.join()}
-                            disabled={!app.voiceControlActions}
-                            className="text-[#a9b8cf] hover:text-white hover:bg-[#22334f]"
-                          >
-                            <Headphones className="size-4" />
-                          </Button>
-                        ) : (
-                          <>
-                            <Button
-                              type="button"
-                              size="icon-xs"
-                              variant="ghost"
-                              onClick={() => app.voiceControlActions?.toggleMute()}
-                              disabled={!app.voiceControlActions}
-                              className={`hover:bg-[#22334f] ${
-                                app.voiceSessionState.isMuted
-                                  ? 'text-[#f3a2a2] hover:text-[#ffd2d2]'
-                                  : 'text-[#a9b8cf] hover:text-white'
-                              }`}
-                            >
-                              {app.voiceSessionState.isMuted ? (
-                                <MicOff className="size-4" />
-                              ) : (
-                                <Mic className="size-4" />
-                              )}
-                            </Button>
-                            <Button
-                              type="button"
-                              size="icon-xs"
-                              variant="ghost"
-                              onClick={() => app.voiceControlActions?.toggleDeafen()}
-                              disabled={!app.voiceControlActions}
-                              className={`hover:bg-[#22334f] ${
-                                app.voiceSessionState.isDeafened
-                                  ? 'text-[#f3a2a2] hover:text-[#ffd2d2]'
-                                  : 'text-[#a9b8cf] hover:text-white'
-                              }`}
-                            >
-                              <VolumeX className="size-4" />
-                            </Button>
-                          </>
-                        )}
-                        <Button
-                          type="button"
-                          size="icon-xs"
-                          variant="ghost"
-                          onClick={() => app.setVoicePanelOpen((prev) => !prev)}
-                          className={`hover:text-white hover:bg-[#22334f] ${
-                            app.voicePanelOpen ? 'text-white' : 'text-[#a9b8cf]'
-                          }`}
-                        >
-                          <Settings2 className="size-4" />
-                        </Button>
-                        <Button
-                          type="button"
-                          size="icon-xs"
-                          variant="ghost"
-                          onClick={() => app.disconnectVoiceSession()}
-                          className="text-[#f0b0b0] hover:text-[#ffd1d1] hover:bg-[#3b2535]"
-                        >
-                          <PhoneOff className="size-4" />
-                        </Button>
-                        <div className="ml-auto text-[11px] text-[#95a5bf]">
-                          {app.activeVoiceParticipantCount} in call
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                  <VoiceDrawer
+                    communityId={app.activeVoiceChannel.community_id}
+                    serverName={app.currentServer.name}
+                    channelId={app.activeVoiceChannel.id}
+                    channelName={app.activeVoiceChannel.name}
+                    currentUserId={user.id}
+                    currentUserDisplayName={app.userDisplayName}
+                    participantCount={app.activeVoiceParticipantCount}
+                    participantPreview={
+                      app.voiceChannelParticipants[app.activeVoiceChannel.id] ?? []
+                    }
+                    voiceConnected={app.voiceConnected}
+                    voicePanelOpen={app.voicePanelOpen}
+                    voiceSessionState={app.voiceSessionState}
+                    voiceControlActions={app.voiceControlActions}
+                    voiceSettings={app.appSettings.voice}
+                    voiceSettingsSaving={app.voiceSettingsSaving}
+                    voiceSettingsError={app.voiceSettingsError}
+                    onToggleOpen={() => app.setVoicePanelOpen((prev) => !prev)}
+                    onDisconnect={() => app.disconnectVoiceSession({ triggerPaneLeave: false })}
+                    onUpdateVoiceSettings={(next) => {
+                      void app.setVoiceSettings(next);
+                    }}
+                    onOpenAdvancedOptions={() => app.setShowVoiceSettingsModal(true)}
+                    onOpenVoiceHardwareTest={() => app.setUserVoiceHardwareTestOpen(true)}
+                    showDiagnostics={app.isPlatformStaff}
+                    onParticipantsChange={app.setVoiceParticipants}
+                    onConnectionChange={app.setVoiceConnected}
+                    onSessionStateChange={app.setVoiceSessionState}
+                    onControlActionsReady={app.setVoiceControlActions}
+                  />
                 ) : null
               }
-              footerStatusActions={
-                <Button
-                  type="button"
-                  size="xs"
-                  variant="ghost"
-                  onClick={() => app.setShowVoiceSettingsModal(true)}
-                  className="text-[#a9b8cf] hover:text-white hover:bg-[#22334f]"
-                  aria-label="Open voice settings"
-                  title="Voice Settings"
-                >
-                  <Headphones className="size-3.5" />
-                  <span>Voice</span>
-                </Button>
-              }
+              footerStatusActions={null}
               onCreateChannel={
                 app.serverPermissions.canCreateChannels
                   ? () => app.setShowCreateChannelModal(true)
@@ -443,55 +365,6 @@ export function ChatApp() {
           </div>
         )}
       </div>
-
-      {app.activeVoiceChannel && (
-        <div
-          className={`fixed inset-0 z-40 flex items-center justify-center p-3 sm:p-6 transition-opacity duration-200 ${
-            app.voicePanelOpen
-              ? 'opacity-100 pointer-events-auto'
-              : 'opacity-0 pointer-events-none'
-          }`}
-          aria-hidden={!app.voicePanelOpen}
-        >
-          <div
-            className={`absolute inset-0 bg-black/60 transition-opacity duration-200 ${
-              app.voicePanelOpen ? 'opacity-100' : 'opacity-0'
-            }`}
-            onClick={() => app.setVoicePanelOpen(false)}
-          />
-          <div
-            className={`relative z-10 w-full max-w-4xl max-h-[88vh] rounded-lg border border-[#304867] bg-[#111a2b] shadow-2xl overflow-hidden transition-all duration-200 ${
-              app.voicePanelOpen ? 'translate-y-0 scale-100' : 'translate-y-3 scale-[0.98]'
-            }`}
-          >
-            <div className="scrollbar-inset max-h-[88vh] overflow-y-auto">
-              <VoiceChannelPane
-                key={`${app.activeVoiceChannel.community_id}:${app.activeVoiceChannel.id}`}
-                communityId={app.activeVoiceChannel.community_id}
-                channelId={app.activeVoiceChannel.id}
-                channelName={app.activeVoiceChannel.name}
-                currentUserId={user.id}
-                currentUserDisplayName={app.userDisplayName}
-                voiceSettings={app.appSettings.voice}
-                voiceSettingsSaving={app.voiceSettingsSaving}
-                voiceSettingsError={app.voiceSettingsError}
-                onUpdateVoiceSettings={(next) => {
-                  void app.setVoiceSettings(next);
-                }}
-                onOpenVoiceSettings={() => app.setShowVoiceSettingsModal(true)}
-                onOpenVoiceHardwareTest={() => app.setUserVoiceHardwareTestOpen(true)}
-                showDiagnostics={app.isPlatformStaff}
-                autoJoin
-                onParticipantsChange={app.setVoiceParticipants}
-                onConnectionChange={app.setVoiceConnected}
-                onSessionStateChange={app.setVoiceSessionState}
-                onControlActionsReady={app.setVoiceControlActions}
-                onLeave={() => app.disconnectVoiceSession({ triggerPaneLeave: false })}
-              />
-            </div>
-          </div>
-        </div>
-      )}
 
       <NotificationCenterModal
         open={app.notificationsPanelOpen}

--- a/packages/shared/src/components/voice/VoiceDrawer.tsx
+++ b/packages/shared/src/components/voice/VoiceDrawer.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import { Button } from '@shared/components/ui/button';
+import { VoiceChannelPane } from '@shared/components/VoiceChannelPane';
+import type { VoiceSettings } from '@platform/desktop/types';
+import { Headphones, Mic, MicOff, PhoneOff, Settings2, VolumeX } from 'lucide-react';
+
+interface VoiceDrawerProps {
+  communityId: string;
+  serverName: string;
+  channelId: string;
+  channelName: string;
+  currentUserId: string;
+  currentUserDisplayName: string;
+  participantCount: number;
+  participantPreview: Array<{ userId: string; displayName: string }>;
+  voiceConnected: boolean;
+  voicePanelOpen: boolean;
+  voiceSessionState: {
+    joined: boolean;
+    isMuted: boolean;
+    isDeafened: boolean;
+  };
+  voiceControlActions:
+    | {
+        join: () => void;
+        leave: () => void;
+        toggleMute: () => void;
+        toggleDeafen: () => void;
+      }
+    | null;
+  voiceSettings: VoiceSettings;
+  voiceSettingsSaving?: boolean;
+  voiceSettingsError?: string | null;
+  showDiagnostics?: boolean;
+  onToggleOpen: () => void;
+  onDisconnect: () => void;
+  onUpdateVoiceSettings: (next: VoiceSettings) => void;
+  onOpenAdvancedOptions: () => void;
+  onOpenVoiceHardwareTest: () => void;
+  onParticipantsChange: (participants: Array<{ userId: string; displayName: string }>) => void;
+  onConnectionChange: (connected: boolean) => void;
+  onSessionStateChange: (state: {
+    joined: boolean;
+    isMuted: boolean;
+    isDeafened: boolean;
+  }) => void;
+  onControlActionsReady: (
+    actions:
+      | {
+          join: () => void;
+          leave: () => void;
+          toggleMute: () => void;
+          toggleDeafen: () => void;
+        }
+      | null
+  ) => void;
+}
+
+export function VoiceDrawer({
+  communityId,
+  serverName,
+  channelId,
+  channelName,
+  currentUserId,
+  currentUserDisplayName,
+  participantCount,
+  participantPreview,
+  voiceConnected,
+  voicePanelOpen,
+  voiceSessionState,
+  voiceControlActions,
+  voiceSettings,
+  voiceSettingsSaving = false,
+  voiceSettingsError = null,
+  showDiagnostics = false,
+  onToggleOpen,
+  onDisconnect,
+  onUpdateVoiceSettings,
+  onOpenAdvancedOptions,
+  onOpenVoiceHardwareTest,
+  onParticipantsChange,
+  onConnectionChange,
+  onSessionStateChange,
+  onControlActionsReady,
+}: VoiceDrawerProps) {
+  return (
+    <div className="px-2 pt-2 pb-1 border-b border-[#22334f]">
+      <div className="rounded-md border border-[#304867] bg-[#142033] px-2 py-2 space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="text-[11px] uppercase tracking-wide text-[#8ea4c7]">Voice Connected</p>
+            <p className="text-xs font-semibold text-white truncate flex items-center gap-1">
+              <Headphones className="size-3.5" />
+              {channelName}
+            </p>
+            <p className="text-[11px] text-[#95a5bf] truncate">{serverName}</p>
+          </div>
+          <span
+            className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
+              voiceConnected
+                ? 'bg-[#2f9f73]/20 text-[#6dd5a6]'
+                : 'bg-[#44546f]/40 text-[#b5c4de]'
+            }`}
+          >
+            {voiceConnected ? 'Live' : 'Connecting'}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-1">
+          {!voiceSessionState.joined ? (
+            <Button
+              type="button"
+              size="icon-xs"
+              variant="ghost"
+              onClick={() => voiceControlActions?.join()}
+              disabled={!voiceControlActions}
+              className="text-[#a9b8cf] hover:text-white hover:bg-[#22334f]"
+              aria-label="Join voice"
+            >
+              <Headphones className="size-4" />
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                onClick={() => voiceControlActions?.toggleMute()}
+                disabled={!voiceControlActions}
+                className={`hover:bg-[#22334f] ${
+                  voiceSessionState.isMuted
+                    ? 'text-[#f3a2a2] hover:text-[#ffd2d2]'
+                    : 'text-[#a9b8cf] hover:text-white'
+                }`}
+                aria-label={voiceSessionState.isMuted ? 'Unmute' : 'Mute'}
+              >
+                {voiceSessionState.isMuted ? (
+                  <MicOff className="size-4" />
+                ) : (
+                  <Mic className="size-4" />
+                )}
+              </Button>
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                onClick={() => voiceControlActions?.toggleDeafen()}
+                disabled={!voiceControlActions}
+                className={`hover:bg-[#22334f] ${
+                  voiceSessionState.isDeafened
+                    ? 'text-[#f3a2a2] hover:text-[#ffd2d2]'
+                    : 'text-[#a9b8cf] hover:text-white'
+                }`}
+                aria-label={voiceSessionState.isDeafened ? 'Undeafen' : 'Deafen'}
+              >
+                <VolumeX className="size-4" />
+              </Button>
+            </>
+          )}
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            onClick={onToggleOpen}
+            className={`hover:text-white hover:bg-[#22334f] ${
+              voicePanelOpen ? 'text-white' : 'text-[#a9b8cf]'
+            }`}
+            aria-label={voicePanelOpen ? 'Collapse voice drawer' : 'Expand voice drawer'}
+          >
+            <Settings2 className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            onClick={onDisconnect}
+            className="text-[#f0b0b0] hover:text-[#ffd1d1] hover:bg-[#3b2535]"
+            aria-label="Leave voice"
+          >
+            <PhoneOff className="size-4" />
+          </Button>
+          <div className="ml-auto text-[11px] text-[#95a5bf]">{participantCount} in call</div>
+        </div>
+
+        <div className="flex items-center gap-1 pl-0.5">
+          {participantPreview.slice(0, 4).map((participant) => {
+            const initial = participant.displayName.trim().charAt(0).toUpperCase() || '?';
+            return (
+              <span
+                key={participant.userId}
+                title={participant.displayName}
+                className="size-5 rounded-full bg-[#304867] text-[10px] text-white font-semibold flex items-center justify-center"
+              >
+                {initial}
+              </span>
+            );
+          })}
+          {participantPreview.length > 4 && (
+            <span className="size-5 rounded-full bg-[#22334f] text-[10px] text-[#d1dff4] font-semibold flex items-center justify-center">
+              +{participantPreview.length - 4}
+            </span>
+          )}
+        </div>
+
+        {voicePanelOpen && (
+          <div className="rounded-md border border-[#22334f] bg-[#111a2b] overflow-hidden">
+            <div className="max-h-[60vh] overflow-y-auto scrollbar-inset p-2">
+              <VoiceChannelPane
+                key={`${communityId}:${channelId}`}
+                communityId={communityId}
+                channelId={channelId}
+                channelName={channelName}
+                currentUserId={currentUserId}
+                currentUserDisplayName={currentUserDisplayName}
+                voiceSettings={voiceSettings}
+                voiceSettingsSaving={voiceSettingsSaving}
+                voiceSettingsError={voiceSettingsError}
+                onUpdateVoiceSettings={onUpdateVoiceSettings}
+                onOpenVoiceSettings={onOpenAdvancedOptions}
+                onOpenVoiceHardwareTest={onOpenVoiceHardwareTest}
+                showDiagnostics={showDiagnostics}
+                autoJoin
+                onParticipantsChange={onParticipantsChange}
+                onConnectionChange={onConnectionChange}
+                onSessionStateChange={onSessionStateChange}
+                onControlActionsReady={onControlActionsReady}
+                onLeave={onDisconnect}
+              />
+              <div className="pt-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={onOpenAdvancedOptions}
+                  className="text-[#a9b8cf] hover:text-white hover:bg-[#22334f]"
+                >
+                  Advanced options
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Factor the inline voice status UI out of `ChatApp` into a reusable component to own compact and expanded voice surfaces and simplify sidebar wiring.
- Rebind the settings control to toggle an inline drawer so the legacy fullscreen voice panel can be retired while keeping existing voice actions functional.
- Keep the legacy `VoiceSettingsModal` available behind an "Advanced options" entry while migrating controls into the inline drawer.

### Description
- Added a new component `packages/shared/src/components/voice/VoiceDrawer.tsx` that implements the compact collapsed state (channel title, live badge, join/mute/deafen/leave/settings controls, member preview) and the expanded inline drawer which embeds `VoiceChannelPane` and exposes an `Advanced options` button.
- Replaced the previous inline `voiceStatusPanel` JSX in `packages/shared/src/client/app/ChatApp.tsx` with `VoiceDrawer` and forwarded all voice state and handlers as props to preserve join/mute/deafen/leave semantics.
- Rebound the settings button in the compact UI to toggle the drawer open/closed (`voicePanelOpen`) and removed the old fullscreen `VoiceChannelPane` modal entrypoint; `VoiceSettingsModal` remains reachable via the drawer's advanced options and other existing flows.
- Left `Sidebar` usage unchanged aside from passing the `VoiceDrawer` via the existing `voiceStatusPanel` prop so no additional voice-specific logic was required in `Sidebar.tsx`.

### Testing
- Ran `npx eslint packages/shared/src/client/app/ChatApp.tsx packages/shared/src/components/voice/VoiceDrawer.tsx` and it completed successfully.
- Started the dev server with `npm run dev:web -- --host 0.0.0.0 --port 4173` and the app served locally (Vite reported ready).
- Captured a Playwright screenshot of the running app to validate the UI rendering, which completed successfully and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84f1bcba08321b215f8d807cf2fce)