### PR TITLE
Extract voice member volume state into reusable hook with per-user persistence

### DIFF
--- a/packages/shared/src/client/features/voice/hooks/useVoiceMemberVolumes.ts
+++ b/packages/shared/src/client/features/voice/hooks/useVoiceMemberVolumes.ts
@@ -1,0 +1,158 @@
+import React from 'react';
+
+const STORAGE_KEY = 'haven:voice:member-volumes:v1';
+const DEFAULT_MEMBER_VOLUME = 100;
+const MIN_MEMBER_VOLUME = 0;
+const MAX_MEMBER_VOLUME = 200;
+const EXPIRY_WINDOW_MS = 1000 * 60 * 60 * 24 * 30;
+const MAX_STORED_ENTRIES = 500;
+
+type StoredVolumeEntry = {
+  volume: number;
+  updatedAt: number;
+};
+
+type StoredVolumeMap = Record<string, StoredVolumeEntry>;
+
+const makeScopedUserKey = (communityId: string, channelId: string, userId: string) =>
+  `${communityId}:${channelId}:${userId}`;
+
+const coerceVolume = (value: number) => {
+  if (!Number.isFinite(value)) return DEFAULT_MEMBER_VOLUME;
+  return Math.max(MIN_MEMBER_VOLUME, Math.min(MAX_MEMBER_VOLUME, Math.round(value)));
+};
+
+const readStoredVolumes = (now: number): StoredVolumeMap => {
+  if (typeof window === 'undefined') return {};
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'object' || parsed == null) return {};
+
+    const entries = Object.entries(parsed as Record<string, unknown>);
+    const pruned: StoredVolumeMap = {};
+
+    for (const [storageKey, value] of entries) {
+      if (typeof value !== 'object' || value == null) continue;
+      const candidate = value as Partial<StoredVolumeEntry>;
+      if (typeof candidate.updatedAt !== 'number' || !Number.isFinite(candidate.updatedAt)) continue;
+      if (now - candidate.updatedAt > EXPIRY_WINDOW_MS) continue;
+      if (typeof candidate.volume !== 'number') continue;
+      pruned[storageKey] = {
+        volume: coerceVolume(candidate.volume),
+        updatedAt: candidate.updatedAt,
+      };
+    }
+
+    return pruned;
+  } catch {
+    return {};
+  }
+};
+
+const writeStoredVolumes = (entries: StoredVolumeMap) => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // Ignore storage failures and keep settings in-memory.
+  }
+};
+
+const pruneMaxEntries = (entries: StoredVolumeMap): StoredVolumeMap => {
+  const sortedEntries = Object.entries(entries).sort(([, left], [, right]) => right.updatedAt - left.updatedAt);
+  return Object.fromEntries(sortedEntries.slice(0, MAX_STORED_ENTRIES));
+};
+
+export const getVoiceMemberVolume = (
+  volumes: Record<string, number>,
+  userId: string
+): number => coerceVolume(volumes[userId] ?? DEFAULT_MEMBER_VOLUME);
+
+export function useVoiceMemberVolumes(communityId: string, channelId: string, connectedUserIds: string[]) {
+  const [volumes, setVolumes] = React.useState<Record<string, number>>({});
+
+  React.useEffect(() => {
+    const now = Date.now();
+    const stored = readStoredVolumes(now);
+
+    // Run periodic storage cleanup when loading this hook.
+    writeStoredVolumes(pruneMaxEntries(stored));
+
+    const nextVolumes: Record<string, number> = {};
+    for (const userId of connectedUserIds) {
+      const entry = stored[makeScopedUserKey(communityId, channelId, userId)];
+      nextVolumes[userId] = coerceVolume(entry?.volume ?? DEFAULT_MEMBER_VOLUME);
+    }
+    setVolumes(nextVolumes);
+  }, [channelId, communityId, connectedUserIds]);
+
+  const persist = React.useCallback(
+    (updater: (current: StoredVolumeMap, now: number) => StoredVolumeMap) => {
+      const now = Date.now();
+      const current = readStoredVolumes(now);
+      const next = updater(current, now);
+      writeStoredVolumes(pruneMaxEntries(next));
+    },
+    []
+  );
+
+  const setMemberVolume = React.useCallback(
+    (userId: string, volume: number) => {
+      const normalized = coerceVolume(volume);
+      setVolumes((current) => ({
+        ...current,
+        [userId]: normalized,
+      }));
+
+      persist((currentStored, now) => ({
+        ...currentStored,
+        [makeScopedUserKey(communityId, channelId, userId)]: {
+          volume: normalized,
+          updatedAt: now,
+        },
+      }));
+    },
+    [channelId, communityId, persist]
+  );
+
+  const resetMemberVolume = React.useCallback(
+    (userId: string) => {
+      setMemberVolume(userId, DEFAULT_MEMBER_VOLUME);
+    },
+    [setMemberVolume]
+  );
+
+  const resetAllMemberVolumes = React.useCallback(() => {
+    setVolumes((current) => {
+      const next: Record<string, number> = {};
+      for (const userId of Object.keys(current)) {
+        next[userId] = DEFAULT_MEMBER_VOLUME;
+      }
+      return next;
+    });
+
+    persist((currentStored, now) => {
+      const nextStored = { ...currentStored };
+      for (const userId of connectedUserIds) {
+        nextStored[makeScopedUserKey(communityId, channelId, userId)] = {
+          volume: DEFAULT_MEMBER_VOLUME,
+          updatedAt: now,
+        };
+      }
+      return nextStored;
+    });
+  }, [channelId, communityId, connectedUserIds, persist]);
+
+  return {
+    remoteVolumes: volumes,
+    setMemberVolume,
+    resetMemberVolume,
+    resetAllMemberVolumes,
+    getMemberVolume: (userId: string) => getVoiceMemberVolume(volumes, userId),
+  };
+}

--- a/packages/shared/src/components/VoiceChannelPane.tsx
+++ b/packages/shared/src/components/VoiceChannelPane.tsx
@@ -3,6 +3,7 @@ import type { RealtimeChannel } from '@supabase/supabase-js';
 import { supabase } from '@shared/lib/supabase';
 import { fetchIceConfig } from '@shared/lib/voice/ice';
 import { matchesVoicePushToTalkBinding } from '@shared/lib/voice/pushToTalk';
+import { useVoiceMemberVolumes } from '@client/features/voice/hooks/useVoiceMemberVolumes';
 import { getErrorMessage } from '@platform/lib/errors';
 import type { VoiceSettings } from '@platform/desktop/types';
 import { Badge } from '@shared/components/ui/badge';
@@ -19,7 +20,7 @@ import {
   SelectValue,
 } from '@shared/components/ui/select';
 import { Toggle } from '@shared/components/ui/toggle';
-import { Headphones, Mic, MicOff, PhoneCall, PhoneOff, RefreshCcw, Volume2 } from 'lucide-react';
+import { Headphones, Mic, MicOff, PhoneCall, PhoneOff, RefreshCcw, RotateCcw, Volume2 } from 'lucide-react';
 
 type VoiceSignalEvent = 'offer' | 'answer' | 'ice';
 
@@ -138,7 +139,6 @@ export function VoiceChannelPane({
   const [joining, setJoining] = useState(false);
   const [participants, setParticipants] = useState<VoiceParticipant[]>([]);
   const [remoteStreams, setRemoteStreams] = useState<Record<string, MediaStream>>({});
-  const [remoteVolumes, setRemoteVolumes] = useState<Record<string, number>>({});
   const [isMuted, setIsMuted] = useState(false);
   const [isDeafened, setIsDeafened] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -187,6 +187,13 @@ export function VoiceChannelPane({
     () => participants.map((participant) => participant.userId),
     [participants]
   );
+  const {
+    remoteVolumes,
+    setMemberVolume,
+    resetMemberVolume,
+    resetAllMemberVolumes,
+    getMemberVolume,
+  } = useVoiceMemberVolumes(communityId, channelId, remoteParticipantIds);
   const diagnosticsRows = useMemo(
     () => Object.values(peerDiagnostics).sort((a, b) => a.displayName.localeCompare(b.displayName)),
     [peerDiagnostics]
@@ -367,12 +374,6 @@ export function VoiceChannelPane({
       return next;
     });
 
-    setRemoteVolumes((prev) => {
-      if (!(remoteUserId in prev)) return prev;
-      const next = { ...prev };
-      delete next[remoteUserId];
-      return next;
-    });
     setPeerDiagnostics((prev) => {
       if (!(remoteUserId in prev)) return prev;
       const next = { ...prev };
@@ -829,7 +830,6 @@ export function VoiceChannelPane({
 
     setParticipants([]);
     setRemoteStreams({});
-    setRemoteVolumes({});
     setPeerDiagnostics({});
     setJoined(false);
     setJoining(false);
@@ -1080,29 +1080,6 @@ export function VoiceChannelPane({
       clearPressed();
     };
   }, [voiceSettings.pushToTalkBinding, voiceSettings.transmissionMode]);
-
-  useEffect(() => {
-    setRemoteVolumes((prev) => {
-      let changed = false;
-      const next = { ...prev };
-
-      for (const participant of participants) {
-        if (typeof next[participant.userId] !== 'number') {
-          next[participant.userId] = 100;
-          changed = true;
-        }
-      }
-
-      for (const existingUserId of Object.keys(next)) {
-        if (!remoteParticipantIds.includes(existingUserId)) {
-          delete next[existingUserId];
-          changed = true;
-        }
-      }
-
-      return changed ? next : prev;
-    });
-  }, [participants, remoteParticipantIds]);
 
   useEffect(() => {
     for (const [remoteUserId, audioElement] of Object.entries(audioElementRefs.current)) {
@@ -1572,43 +1549,66 @@ export function VoiceChannelPane({
           {participants.length === 0 ? (
             <p className="text-sm text-[#a9b8cf]">No other participants are connected.</p>
           ) : (
-            participants.map((participant) => (
-              <div
-                key={participant.userId}
-                className="flex items-center justify-between rounded-md border border-[#304867] bg-[#142033] px-3 py-2 gap-3"
-              >
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-white truncate">{participant.displayName}</p>
-                  <div className="mt-1 flex items-center gap-2">
-                    {participant.muted && <Badge variant="outline">Muted</Badge>}
-                    {participant.deafened && <Badge variant="outline">Deafened</Badge>}
+            <>
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={resetAllMemberVolumes}
+                  className="h-8 text-xs text-[#c8d7ee] hover:text-white"
+                  disabled={isDeafened}
+                >
+                  <RotateCcw className="mr-1.5 size-3.5" />
+                  Reset all member volumes
+                </Button>
+              </div>
+
+              {participants.map((participant) => (
+                <div
+                  key={participant.userId}
+                  className="flex items-center justify-between rounded-md border border-[#304867] bg-[#142033] px-3 py-2 gap-3"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-white truncate">{participant.displayName}</p>
+                    <div className="mt-1 flex items-center gap-2">
+                      {participant.muted && <Badge variant="outline">Muted</Badge>}
+                      {participant.deafened && <Badge variant="outline">Deafened</Badge>}
+                    </div>
+                  </div>
+
+                  <div className="flex min-w-[220px] items-center gap-3">
+                    <Volume2 className="size-4 text-[#a9b8cf]" />
+                    <Slider
+                      min={REMOTE_VOLUME_OPTIONS[0]}
+                      max={REMOTE_VOLUME_OPTIONS[REMOTE_VOLUME_OPTIONS.length - 1]}
+                      step={25}
+                      value={[getMemberVolume(participant.userId)]}
+                      onValueChange={(values) => {
+                        const numericValue = values[0];
+                        setMemberVolume(participant.userId, numericValue);
+                      }}
+                      disabled={isDeafened}
+                      className="w-full"
+                      aria-label={`Volume for ${participant.displayName}`}
+                    />
+                    <span className="w-10 shrink-0 text-right text-xs text-[#c8d7ee]">
+                      {getMemberVolume(participant.userId)}%
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => resetMemberVolume(participant.userId)}
+                      disabled={isDeafened}
+                      className="h-8 px-2 text-xs"
+                    >
+                      100%
+                    </Button>
                   </div>
                 </div>
-
-                <div className="flex min-w-[180px] items-center gap-3">
-                  <Volume2 className="size-4 text-[#a9b8cf]" />
-                  <Slider
-                    min={REMOTE_VOLUME_OPTIONS[0]}
-                    max={REMOTE_VOLUME_OPTIONS[REMOTE_VOLUME_OPTIONS.length - 1]}
-                    step={25}
-                    value={[remoteVolumes[participant.userId] ?? 100]}
-                    onValueChange={(values) => {
-                      const numericValue = values[0];
-                      setRemoteVolumes((prev) => ({
-                        ...prev,
-                        [participant.userId]: Number.isFinite(numericValue) ? numericValue : 100,
-                      }));
-                    }}
-                    disabled={isDeafened}
-                    className="w-full"
-                    aria-label={`Volume for ${participant.displayName}`}
-                  />
-                  <span className="w-10 shrink-0 text-right text-xs text-[#c8d7ee]">
-                    {remoteVolumes[participant.userId] ?? 100}%
-                  </span>
-                </div>
-              </div>
-            ))
+              ))}
+            </>
           )}
         </CardContent>
       </Card>
@@ -1641,4 +1641,3 @@ export function VoiceChannelPane({
     </div>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Keep per-member remote volume state out of the `VoiceChannelPane` UI so it can be reused and tested independently.
- Ensure per-member gain is persisted locally and scoped to server/channel to survive reloads and not be lost inside the pane layout.
- Provide per-member and global reset controls so users can quickly restore sane defaults.

### Description
- Added a new hook `useVoiceMemberVolumes` (`packages/shared/src/client/features/voice/hooks/useVoiceMemberVolumes.ts`) that persists per-user volumes to `localStorage` keyed by `communityId:channelId:userId`, with coercion and bounds (`0–200`), stale-entry expiry (30 days), and max-entry pruning (`500`).
- Updated `VoiceChannelPane` to consume `useVoiceMemberVolumes` (removed the internal `remoteVolumes` state) and wire slider changes via the hook (`setMemberVolume`, `getMemberVolume`), while leaving the existing remote audio application path (`audioElement.volume = (remoteVolumes[...] ?? 100) / 100`) intact.
- Render one slider per connected member keyed by `participant.userId`, added a per-member reset button (`resetMemberVolume`) that restores `100%`, and added a global `Reset all member volumes` button (`resetAllMemberVolumes`) in the expanded participants list.
- Minor UI changes: imported `RotateCcw` icon and adjusted slider container sizing to accommodate the reset buttons; ensured cleanup no longer tried to mutate removed local state.

### Testing
- Ran linting with `npx eslint packages/shared/src/components/VoiceChannelPane.tsx packages/shared/src/client/features/voice/hooks/useVoiceMemberVolumes.ts` which passed.
- Type-checked the workspace with `npx tsc --noEmit --project tsconfig.json` which passed.
- Launched the dev server with `npm run dev:web -- --host 0.0.0.0 --port 4173` and captured a screenshot to validate the UI (screenshot artifact recorded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85475355c8321be0dba0d928f98e6)