### PR TITLE
Add recovery doc for restored branch `haven-work-b104609`

### DIFF
--- a/docs/recovery/haven-work-b104609.md
+++ b/docs/recovery/haven-work-b104609.md
@@ -1,0 +1,18 @@
+# Recovered branch pointer: haven-work-b104609
+
+Recovered from Git object database using:
+
+- `git fsck --full --no-reflogs`
+
+Recovered tip commit:
+
+- `b508a59a1f90d975bd652b738c4704c6fb26c5d0` (`1.6.0`)
+
+A local branch pointer was recreated for this recovered history:
+
+- `haven-work-b104609` -> `b508a59a1f90d975bd652b738c4704c6fb26c5d0`
+
+If needed, compare it with current `work` branch:
+
+- `git log --oneline work..haven-work-b104609`
+- `git log --oneline haven-work-b104609..work`


### PR DESCRIPTION
### Motivation
- Recreate and document a recovered branch pointer retrieved from the Git object database after running `git fsck --full --no-reflogs`.

### Description
- Add `docs/recovery/haven-work-b104609.md` documenting the recovered tip commit `b508a59a1f90d975bd652b738c4704c6fb26c5d0` and the recreated local branch pointer `haven-work-b104609`, with suggested `git log` comparisons.

### Testing
- No automated tests were applicable or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8888a08b88321b9c3182dd2914942)