### PR TITLE
chore(desktop): macOS signing + mic entitlement (2.0.1)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -113,6 +113,19 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
+      # Write the App Store Connect API key (.p8) to the standard notarytool
+      # search path so tauri-action's notarization step finds it automatically.
+      # notarytool searches: ~/.appstoreconnect/private_keys/AuthKey_KEYID.p8
+      - name: Write App Store Connect API key
+        if: runner.os == 'macOS'
+        env:
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$APPLE_API_KEY_CONTENT" | base64 --decode \
+            > ~/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY}.p8
+
       # Upload to the single release created above (by id, never by tag) so all
       # platforms land in one draft with one combined latest.json.
       - name: Build, sign, and upload
@@ -125,6 +138,14 @@ jobs:
           # Without these the packaged app throws at boot and hangs on the splash.
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          # macOS Developer ID signing + notarization via App Store Connect API key.
+          # Certificate import is handled by tauri-action when these three are set.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # notarytool picks up the .p8 written above from its standard search path.
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         with:
           projectPath: apps/tauri
           releaseId: ${{ needs.create-release.outputs.release_id }}

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "haven-tauri"
-version = "2.0.0"
+version = "2.0.1"
 description = "Haven desktop"
 authors = ["redrix-dev"]
 edition = "2021"

--- a/apps/tauri/src-tauri/Entitlements.plist
+++ b/apps/tauri/src-tauri/Entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Required for WKWebView to function under hardened runtime -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- Microphone access for voice channels -->
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/tauri/src-tauri/Info.plist
+++ b/apps/tauri/src-tauri/Info.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Haven needs microphone access to join voice channels.</string>
+</dict>
+</plist>

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Haven",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "identifier": "com.redrixx.haven",
   "build": {
     "beforeDevCommand": "npm run dev:solid",

--- a/apps/tauri/src-tauri/tauri.macos.conf.json
+++ b/apps/tauri/src-tauri/tauri.macos.conf.json
@@ -13,5 +13,11 @@
         "backgroundColor": "#0d1626"
       }
     ]
+  },
+  "bundle": {
+    "macOS": {
+      "entitlements": "./Entitlements.plist",
+      "minimumSystemVersion": "12.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haven",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Haven",
   "private": true,
   "repository": {

--- a/packages/solid-client/src/contexts/VoiceProvider.tsx
+++ b/packages/solid-client/src/contexts/VoiceProvider.tsx
@@ -326,6 +326,15 @@ export function VoiceProvider(props: { children: JSX.Element }) {
       await room.connect(serverUrl, token, { autoSubscribe: true });
       if (generation !== joinGeneration) return;
 
+      // On macOS, WKWebView only exposes navigator.mediaDevices when the app is
+      // signed with the audio-input entitlement. Guard here so the catch block
+      // below surfaces a legible message instead of "undefined is not an object".
+      if (!navigator.mediaDevices) {
+        throw new Error(
+          "Microphone access is unavailable. On macOS, please check System Settings → Privacy & Security → Microphone and ensure Haven is allowed.",
+        );
+      }
+
       const profile = viewerProfile();
       void room.localParticipant
         .setMetadata(JSON.stringify({ avatarUrl: profile?.avatarUrl ?? null }))


### PR DESCRIPTION
Wires Developer ID signing and notarization into the release workflow, adds mic entitlement for voice channels, bumps to 2.0.1.