### PR TITLE
feat(voice): Linux native voice — production parity (device selection, deafen, per-member volume, speaking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,20 @@ jobs:
       - name: Stop Supabase
         if: always()
         run: supabase stop
+
+  # Compile-check the native voice sidecar (its own Cargo workspace, pinned to
+  # an unreleased libwebrtc — see docs/architecture/NATIVE_VOICE.md). Runs in
+  # parallel with `verify`; --locked also proves haven-voice/Cargo.lock is sound.
+  sidecar:
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./apps/tauri/haven-voice -> target"
+      - name: Install audio dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Build native voice sidecar
+        run: cargo build --locked --manifest-path apps/tauri/haven-voice/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,17 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: "./apps/tauri/haven-voice -> target"
-      - name: Install audio dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      # cpal needs ALSA; webrtc-sys's prebuilt libwebrtc links the GTK/glib
+      # desktop stack (glib-2.0, gio) at build time — same set the release
+      # workflow installs before building the sidecar.
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev \
+            libglib2.0-dev \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev
       - name: Build native voice sidecar
         run: cargo build --locked --manifest-path apps/tauri/haven-voice/Cargo.toml

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -98,7 +98,11 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: "./apps/tauri/src-tauri -> target"
+          # Two independent Cargo workspaces: the Tauri app and the standalone
+          # native voice sidecar (Linux).
+          workspaces: |
+            ./apps/tauri/src-tauri -> target
+            ./apps/tauri/haven-voice -> target
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
@@ -108,10 +112,18 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \
-            patchelf
+            patchelf \
+            libasound2-dev
 
       - name: Install JS dependencies
         run: npm ci
+
+      # Build + stage the native voice sidecar so tauri-action bundles it as an
+      # externalBin (declared Linux-only in tauri.linux.conf.json). Linux is the
+      # only platform that ships the sidecar today; mac/win keep in-webview voice.
+      - name: Build native voice sidecar (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: node tooling/scripts/stage-haven-voice-sidecar.mjs
 
       # Write the App Store Connect API key (.p8) to the standard notarytool
       # search path so tauri-action's notarization step finds it automatically.

--- a/apps/tauri/haven-voice/Cargo.lock
+++ b/apps/tauri/haven-voice/Cargo.lock
@@ -876,6 +876,8 @@ dependencies = [
  "futures-util",
  "livekit",
  "log",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/apps/tauri/haven-voice/Cargo.toml
+++ b/apps/tauri/haven-voice/Cargo.toml
@@ -28,3 +28,6 @@ cpal = "0.15"
 anyhow = "1"
 log = "0.4"
 env_logger = "0.11"
+# Newline-delimited JSON control/event protocol with the Tauri shell.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/apps/tauri/haven-voice/src/audio_mixer.rs
+++ b/apps/tauri/haven-voice/src/audio_mixer.rs
@@ -1,4 +1,5 @@
 use crate::db_meter::calculate_db_level;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
@@ -7,11 +8,19 @@ pub struct AudioMixer {
     buffer: Arc<Mutex<std::collections::VecDeque<i16>>>,
     sample_rate: u32,
     channels: u32,
-    volume: f32,
+    // Master output gain, 0.0..=1.0, stored as f32 bits so it can be set at
+    // runtime (e.g. deafen → 0.0) and shared across clones without a lock in
+    // the per-sample path.
+    volume: Arc<AtomicU32>,
     max_buffer_size: usize,
     db_tx: Option<mpsc::UnboundedSender<f32>>,
     // Channel to send reference audio for echo cancellation
     reference_audio_tx: Option<mpsc::UnboundedSender<Vec<i16>>>,
+}
+
+/// Build the shared, clamped master-volume cell from an initial gain.
+fn volume_cell(volume: f32) -> Arc<AtomicU32> {
+    Arc::new(AtomicU32::new(volume.clamp(0.0, 1.0).to_bits()))
 }
 
 impl AudioMixer {
@@ -25,7 +34,7 @@ impl AudioMixer {
             ))),
             sample_rate,
             channels,
-            volume: volume.clamp(0.0, 1.0),
+            volume: volume_cell(volume),
             max_buffer_size,
             db_tx: None,
             reference_audio_tx: None,
@@ -47,7 +56,7 @@ impl AudioMixer {
             ))),
             sample_rate,
             channels,
-            volume: volume.clamp(0.0, 1.0),
+            volume: volume_cell(volume),
             max_buffer_size,
             db_tx: Some(db_tx),
             reference_audio_tx: None,
@@ -70,7 +79,7 @@ impl AudioMixer {
             ))),
             sample_rate,
             channels,
-            volume: volume.clamp(0.0, 1.0),
+            volume: volume_cell(volume),
             max_buffer_size,
             db_tx: Some(db_tx),
             reference_audio_tx: Some(reference_audio_tx),
@@ -78,11 +87,12 @@ impl AudioMixer {
     }
 
     pub fn add_audio_data(&self, data: &[i16]) {
+        let volume = self.volume();
         let mut buffer = self.buffer.lock().unwrap();
 
         // Apply volume scaling and add to buffer
         for &sample in data.iter() {
-            let scaled_sample = (sample as f32 * self.volume) as i16;
+            let scaled_sample = (sample as f32 * volume) as i16;
             buffer.push_back(scaled_sample);
 
             // Prevent buffer from growing too large
@@ -90,6 +100,18 @@ impl AudioMixer {
                 buffer.pop_front();
             }
         }
+    }
+
+    /// Current master output gain (0.0..=1.0).
+    pub fn volume(&self) -> f32 {
+        f32::from_bits(self.volume.load(Ordering::Relaxed))
+    }
+
+    /// Set the master output gain (0.0..=1.0). Deafen sets 0.0; the change is
+    /// shared across every clone of this mixer. Takes effect on the next frame.
+    pub fn set_volume(&self, volume: f32) {
+        self.volume
+            .store(volume.clamp(0.0, 1.0).to_bits(), Ordering::Relaxed);
     }
 
     pub fn get_samples(&self, requested_samples: usize) -> Vec<i16> {

--- a/apps/tauri/haven-voice/src/main.rs
+++ b/apps/tauri/haven-voice/src/main.rs
@@ -243,7 +243,8 @@ async fn main() -> Result<()> {
                                 }),
                             }
                         }
-                        // Volume commands land in later slices.
+                        Ok(Command::SetMasterVolume { value }) => mixer.set_volume(value),
+                        // Per-member volume lands in the next slice.
                         Ok(other) => {
                             log::warn!("haven-voice: command not yet implemented: {other:?}");
                         }

--- a/apps/tauri/haven-voice/src/main.rs
+++ b/apps/tauri/haven-voice/src/main.rs
@@ -180,36 +180,50 @@ async fn main() -> Result<()> {
         tokio::spawn(async move {
             let mut events = room.subscribe();
             while let Some(event) = events.recv().await {
-                // Only the audio-critical event; the participant roster is driven
-                // by the existing Supabase presence channel on the UI side.
-                if let RoomEvent::TrackSubscribed { track, participant, .. } = event {
-                    if let RemoteTrack::Audio(audio_track) = track {
-                        let mut stream =
-                            NativeAudioStream::new(audio_track.rtc_track(), SAMPLE_RATE as i32, 1);
-                        let mixer = mixer.clone();
-                        let member_gains = member_gains.clone();
-                        let identity = participant.identity().to_string();
-                        tokio::spawn(async move {
-                            while let Some(frame) = stream.next().await {
-                                let samples = frame.data.as_ref();
-                                let gain = member_gains
-                                    .lock()
-                                    .unwrap()
-                                    .get(&identity)
-                                    .copied()
-                                    .unwrap_or(1.0);
-                                if gain >= 0.999 {
-                                    mixer.add_audio_data(samples);
-                                } else {
-                                    let scaled: Vec<i16> = samples
-                                        .iter()
-                                        .map(|&s| (s as f32 * gain) as i16)
-                                        .collect();
-                                    mixer.add_audio_data(&scaled);
+                match event {
+                    // Remote audio → per-member gain → mixer. The roster itself
+                    // is driven by the Supabase presence channel on the UI side.
+                    RoomEvent::TrackSubscribed { track, participant, .. } => {
+                        if let RemoteTrack::Audio(audio_track) = track {
+                            let mut stream = NativeAudioStream::new(
+                                audio_track.rtc_track(),
+                                SAMPLE_RATE as i32,
+                                1,
+                            );
+                            let mixer = mixer.clone();
+                            let member_gains = member_gains.clone();
+                            let identity = participant.identity().to_string();
+                            tokio::spawn(async move {
+                                while let Some(frame) = stream.next().await {
+                                    let samples = frame.data.as_ref();
+                                    let gain = member_gains
+                                        .lock()
+                                        .unwrap()
+                                        .get(&identity)
+                                        .copied()
+                                        .unwrap_or(1.0);
+                                    if gain >= 0.999 {
+                                        mixer.add_audio_data(samples);
+                                    } else {
+                                        let scaled: Vec<i16> = samples
+                                            .iter()
+                                            .map(|&s| (s as f32 * gain) as i16)
+                                            .collect();
+                                        mixer.add_audio_data(&scaled);
+                                    }
                                 }
-                            }
-                        });
+                            });
+                        }
                     }
+                    // Speaking indicators: forward the active-speaker set so the
+                    // presence-driven roster can light up who's talking (parity
+                    // with web/mac/win, which read LiveKit ActiveSpeakersChanged).
+                    RoomEvent::ActiveSpeakersChanged { speakers } => {
+                        let identities: Vec<String> =
+                            speakers.iter().map(|p| p.identity().to_string()).collect();
+                        emit(&Event::Speaking { identities });
+                    }
+                    _ => {}
                 }
             }
         });

--- a/apps/tauri/haven-voice/src/main.rs
+++ b/apps/tauri/haven-voice/src/main.rs
@@ -3,20 +3,24 @@
 //! Adapted from LiveKit's `local_audio` example (proven on this hardware).
 //! Joins a room with a SERVER-MINTED token (from Haven's `voice-token` function
 //! — never the API secret), captures the mic, plays remote participants, and
-//! runs libwebrtc echo cancellation. Driven by the Tauri app over stdio:
+//! runs libwebrtc echo cancellation. Driven by the Tauri app over stdio using a
+//! newline-delimited JSON protocol (one JSON object per line — see protocol.rs):
 //!
-//!   stdin  (one command per line):  mute | unmute | leave
-//!   stdout (one event per line):    connected | ready | disconnected | error <msg>
+//!   stdin  (commands):  {"type":"mute"} | {"type":"unmute"} | {"type":"leave"} | …
+//!   stdout (events):    {"type":"connected"} | {"type":"ready"} |
+//!                       {"type":"disconnected"} | {"type":"error","message":…}
 //!
 //! Config via env:  LIVEKIT_URL, LIVEKIT_TOKEN.
 //!
 //! Test standalone (no Tauri):
 //!   LIVEKIT_URL=wss://... LIVEKIT_TOKEN=<join jwt> cargo run
+//!   then type JSON commands on stdin, e.g. {"type":"mute"}
 
 mod audio_capture;
 mod audio_mixer;
 mod audio_playback;
 mod db_meter;
+mod protocol;
 
 use anyhow::{anyhow, Result};
 use audio_capture::AudioCapture;
@@ -37,6 +41,7 @@ use livekit::{
     },
     Room, RoomEvent, RoomOptions,
 };
+use protocol::{Command, Event};
 use std::io::Write;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -45,10 +50,15 @@ use tokio::sync::{mpsc, Mutex};
 const SAMPLE_RATE: u32 = 48_000;
 const SAMPLES_PER_10MS: usize = (SAMPLE_RATE / 100) as usize;
 
-/// Emit one event line to the parent (Tauri) and flush immediately.
-fn emit(line: &str) {
-    println!("{line}");
-    let _ = std::io::stdout().flush();
+/// Emit one event to the parent (Tauri) as a JSON line and flush immediately.
+fn emit(event: &Event) {
+    match serde_json::to_string(event) {
+        Ok(line) => {
+            println!("{line}");
+            let _ = std::io::stdout().flush();
+        }
+        Err(e) => eprintln!("haven-voice: failed to serialize event {event:?}: {e}"),
+    }
 }
 
 #[tokio::main]
@@ -63,11 +73,11 @@ async fn main() -> Result<()> {
     let room = match Room::connect(&url, &token, opts).await {
         Ok((room, _rx)) => Arc::new(room),
         Err(e) => {
-            emit(&format!("error connect_failed: {e}"));
+            emit(&Event::Error { message: format!("connect_failed: {e}") });
             return Err(e.into());
         }
     };
-    emit("connected");
+    emit(&Event::Connected);
 
     // ── shared echo-cancellation processor (APM) ───────────────────────────
     // args: echo_cancellation, auto_gain_control, high_pass_filter, noise_suppression
@@ -207,20 +217,29 @@ async fn main() -> Result<()> {
         });
     }
 
-    emit("ready");
+    emit(&Event::Ready);
 
-    // ── stdin control loop (mute / unmute / leave) ─────────────────────────
+    // ── stdin control loop (JSON commands, one per line) ───────────────────
     let mut lines = BufReader::new(tokio::io::stdin()).lines();
     loop {
         tokio::select! {
             line = lines.next_line() => match line {
-                Ok(Some(cmd)) => match cmd.trim() {
-                    "mute" => track.mute(),
-                    "unmute" => track.unmute(),
-                    "leave" => break,
-                    "" => {}
-                    other => eprintln!("haven-voice: unknown command {other:?}"),
-                },
+                Ok(Some(cmd)) => {
+                    let trimmed = cmd.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    match serde_json::from_str::<Command>(trimmed) {
+                        Ok(Command::Mute) => track.mute(),
+                        Ok(Command::Unmute) => track.unmute(),
+                        Ok(Command::Leave) => break,
+                        // Device/volume/enumeration commands land in later slices.
+                        Ok(other) => {
+                            log::warn!("haven-voice: command not yet implemented: {other:?}");
+                        }
+                        Err(e) => eprintln!("haven-voice: bad command {trimmed:?}: {e}"),
+                    }
+                }
                 // stdin closed → parent process gone → exit.
                 _ => break,
             },
@@ -229,6 +248,6 @@ async fn main() -> Result<()> {
     }
 
     let _ = room.close().await;
-    emit("disconnected");
+    emit(&Event::Disconnected);
     Ok(())
 }

--- a/apps/tauri/haven-voice/src/main.rs
+++ b/apps/tauri/haven-voice/src/main.rs
@@ -42,6 +42,7 @@ use livekit::{
     Room, RoomEvent, RoomOptions,
 };
 use protocol::{Command, DeviceInfo, Event};
+use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -164,23 +165,48 @@ async fn main() -> Result<()> {
         });
     }
 
+    // Per-participant playback gain (LiveKit identity → 0.0..=1.0), applied
+    // before the mixer. Absent == full volume. Shared with the stdin loop so
+    // slider moves take effect live. The identity equals the Haven user id (the
+    // token mints it that way), so it matches the UI's memberVolumes keys.
+    let member_gains: Arc<std::sync::Mutex<HashMap<String, f32>>> =
+        Arc::new(std::sync::Mutex::new(HashMap::new()));
+
     // ── remote audio tracks → mixer ────────────────────────────────────────
     {
         let room = room.clone();
         let mixer = mixer.clone();
+        let member_gains = member_gains.clone();
         tokio::spawn(async move {
             let mut events = room.subscribe();
             while let Some(event) = events.recv().await {
-                // Only the audio-critical event for now; participant roster is
-                // driven by the existing Supabase presence channel on the UI side.
-                if let RoomEvent::TrackSubscribed { track, .. } = event {
+                // Only the audio-critical event; the participant roster is driven
+                // by the existing Supabase presence channel on the UI side.
+                if let RoomEvent::TrackSubscribed { track, participant, .. } = event {
                     if let RemoteTrack::Audio(audio_track) = track {
                         let mut stream =
                             NativeAudioStream::new(audio_track.rtc_track(), SAMPLE_RATE as i32, 1);
                         let mixer = mixer.clone();
+                        let member_gains = member_gains.clone();
+                        let identity = participant.identity().to_string();
                         tokio::spawn(async move {
                             while let Some(frame) = stream.next().await {
-                                mixer.add_audio_data(frame.data.as_ref());
+                                let samples = frame.data.as_ref();
+                                let gain = member_gains
+                                    .lock()
+                                    .unwrap()
+                                    .get(&identity)
+                                    .copied()
+                                    .unwrap_or(1.0);
+                                if gain >= 0.999 {
+                                    mixer.add_audio_data(samples);
+                                } else {
+                                    let scaled: Vec<i16> = samples
+                                        .iter()
+                                        .map(|&s| (s as f32 * gain) as i16)
+                                        .collect();
+                                    mixer.add_audio_data(&scaled);
+                                }
                             }
                         });
                     }
@@ -244,9 +270,11 @@ async fn main() -> Result<()> {
                             }
                         }
                         Ok(Command::SetMasterVolume { value }) => mixer.set_volume(value),
-                        // Per-member volume lands in the next slice.
-                        Ok(other) => {
-                            log::warn!("haven-voice: command not yet implemented: {other:?}");
+                        Ok(Command::SetMemberVolume { identity, value }) => {
+                            member_gains
+                                .lock()
+                                .unwrap()
+                                .insert(identity, value.clamp(0.0, 1.0));
                         }
                         Err(e) => eprintln!("haven-voice: bad command {trimmed:?}: {e}"),
                     }

--- a/apps/tauri/haven-voice/src/main.rs
+++ b/apps/tauri/haven-voice/src/main.rs
@@ -41,7 +41,7 @@ use livekit::{
     },
     Room, RoomEvent, RoomOptions,
 };
-use protocol::{Command, Event};
+use protocol::{Command, DeviceInfo, Event};
 use std::io::Write;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -107,28 +107,18 @@ async fn main() -> Result<()> {
 
     let host = cpal::default_host();
 
-    // mic capture → APM (forward stream) → livekit
-    let input_device = host
-        .default_input_device()
-        .ok_or_else(|| anyhow!("no default input device"))?;
-    let in_supported = input_device.default_input_config()?;
-    let in_channels = in_supported.channels() as u32;
-    let in_config = StreamConfig {
-        channels: in_supported.channels(),
-        sample_rate: SampleRate(SAMPLE_RATE),
-        buffer_size: cpal::BufferSize::Default,
-    };
+    // The mpsc channels and the mixer are STABLE for the whole session; only the
+    // cpal capture/playback streams below are torn down and rebuilt when the user
+    // picks a different device (see the SetInputDevice/SetOutputDevice handlers).
     let (mic_tx, mut mic_rx) = mpsc::unbounded_channel::<Vec<i16>>();
-    let _capture = AudioCapture::new(
-        input_device,
-        in_config,
-        in_supported.sample_format(),
-        mic_tx,
-        None,
-        0, // capture channel 0
-        in_channels,
-    )
-    .await?;
+    let (ref_tx, mut ref_rx) = mpsc::unbounded_channel::<Vec<i16>>();
+    let (db_tx, _db_rx) = mpsc::unbounded_channel::<f32>();
+    let mixer = AudioMixer::with_reference_audio(SAMPLE_RATE, 1, 1.0, db_tx, ref_tx);
+
+    // mic capture → APM (forward stream) → livekit. Held in an Option so a device
+    // switch can drop the old stream (freeing the device) before opening the new.
+    let input_device = resolve_input_device(&host, None)?;
+    let mut capture = Some(build_capture(input_device, mic_tx.clone()).await?);
 
     {
         let apm = apm.clone();
@@ -153,26 +143,8 @@ async fn main() -> Result<()> {
     }
 
     // ── playback: mixer (feeds reference audio to AEC) + output stream ──────
-    let (ref_tx, mut ref_rx) = mpsc::unbounded_channel::<Vec<i16>>();
-    let (db_tx, _db_rx) = mpsc::unbounded_channel::<f32>();
-    let mixer = AudioMixer::with_reference_audio(SAMPLE_RATE, 1, 1.0, db_tx, ref_tx);
-
-    let output_device = host
-        .default_output_device()
-        .ok_or_else(|| anyhow!("no default output device"))?;
-    let out_supported = output_device.default_output_config()?;
-    let out_config = StreamConfig {
-        channels: 1,
-        sample_rate: SampleRate(SAMPLE_RATE),
-        buffer_size: cpal::BufferSize::Default,
-    };
-    let _playback = AudioPlayback::new(
-        output_device,
-        out_config,
-        out_supported.sample_format(),
-        mixer.clone(),
-    )
-    .await?;
+    let output_device = resolve_output_device(&host, None)?;
+    let mut playback = Some(build_playback(output_device, mixer.clone()).await?);
 
     // reference audio (what we play) → APM (reverse stream) for echo cancellation
     {
@@ -233,7 +205,45 @@ async fn main() -> Result<()> {
                         Ok(Command::Mute) => track.mute(),
                         Ok(Command::Unmute) => track.unmute(),
                         Ok(Command::Leave) => break,
-                        // Device/volume/enumeration commands land in later slices.
+                        Ok(Command::EnumerateDevices) => {
+                            let (inputs, outputs) = enumerate_devices(&host);
+                            emit(&Event::Devices { inputs, outputs });
+                        }
+                        Ok(Command::SetInputDevice { id }) => {
+                            match resolve_input_device(&host, Some(id.as_str())) {
+                                Ok(device) => {
+                                    // Drop the old stream first so the device is
+                                    // free to reopen (some backends are exclusive).
+                                    drop(capture.take());
+                                    match build_capture(device, mic_tx.clone()).await {
+                                        Ok(c) => capture = Some(c),
+                                        Err(e) => emit(&Event::Error {
+                                            message: format!("input_device_failed: {e}"),
+                                        }),
+                                    }
+                                }
+                                Err(e) => emit(&Event::Error {
+                                    message: format!("input_device_error: {e}"),
+                                }),
+                            }
+                        }
+                        Ok(Command::SetOutputDevice { id }) => {
+                            match resolve_output_device(&host, Some(id.as_str())) {
+                                Ok(device) => {
+                                    drop(playback.take());
+                                    match build_playback(device, mixer.clone()).await {
+                                        Ok(p) => playback = Some(p),
+                                        Err(e) => emit(&Event::Error {
+                                            message: format!("output_device_failed: {e}"),
+                                        }),
+                                    }
+                                }
+                                Err(e) => emit(&Event::Error {
+                                    message: format!("output_device_error: {e}"),
+                                }),
+                            }
+                        }
+                        // Volume commands land in later slices.
                         Ok(other) => {
                             log::warn!("haven-voice: command not yet implemented: {other:?}");
                         }
@@ -250,4 +260,81 @@ async fn main() -> Result<()> {
     let _ = room.close().await;
     emit(&Event::Disconnected);
     Ok(())
+}
+
+/// Resolve an input device by cpal name, or the system default when `id` is None.
+fn resolve_input_device(host: &cpal::Host, id: Option<&str>) -> Result<cpal::Device> {
+    match id {
+        Some(name) => host
+            .input_devices()?
+            .find(|d| d.name().ok().as_deref() == Some(name))
+            .ok_or_else(|| anyhow!("input device {name:?} not found")),
+        None => host
+            .default_input_device()
+            .ok_or_else(|| anyhow!("no default input device")),
+    }
+}
+
+/// Resolve an output device by cpal name, or the system default when `id` is None.
+fn resolve_output_device(host: &cpal::Host, id: Option<&str>) -> Result<cpal::Device> {
+    match id {
+        Some(name) => host
+            .output_devices()?
+            .find(|d| d.name().ok().as_deref() == Some(name))
+            .ok_or_else(|| anyhow!("output device {name:?} not found")),
+        None => host
+            .default_output_device()
+            .ok_or_else(|| anyhow!("no default output device")),
+    }
+}
+
+/// List selectable input/output devices. `id` == cpal device name (see
+/// `DeviceInfo`); devices whose name can't be read are skipped.
+fn enumerate_devices(host: &cpal::Host) -> (Vec<DeviceInfo>, Vec<DeviceInfo>) {
+    fn to_infos<I: Iterator<Item = cpal::Device>>(devices: I) -> Vec<DeviceInfo> {
+        devices
+            .filter_map(|d| d.name().ok())
+            .map(|name| DeviceInfo { id: name.clone(), label: name })
+            .collect()
+    }
+    let inputs = host.input_devices().map(to_infos).unwrap_or_default();
+    let outputs = host.output_devices().map(to_infos).unwrap_or_default();
+    (inputs, outputs)
+}
+
+/// Build a mic-capture stream on `device`, downmixing to mono i16 into `mic_tx`.
+/// Rebuilt on device switch; the `mic_tx` end stays wired to the APM pipeline.
+async fn build_capture(
+    device: cpal::Device,
+    mic_tx: mpsc::UnboundedSender<Vec<i16>>,
+) -> Result<AudioCapture> {
+    let supported = device.default_input_config()?;
+    let channels = supported.channels() as u32;
+    let config = StreamConfig {
+        channels: supported.channels(),
+        sample_rate: SampleRate(SAMPLE_RATE),
+        buffer_size: cpal::BufferSize::Default,
+    };
+    AudioCapture::new(
+        device,
+        config,
+        supported.sample_format(),
+        mic_tx,
+        None,
+        0, // capture channel 0 (voice is mono — LiveKit downmixes anyway)
+        channels,
+    )
+    .await
+}
+
+/// Build a playback stream on `device`, pulling mixed mono i16 from `mixer`.
+/// Rebuilt on device switch; the `mixer` (and its AEC reference tap) is stable.
+async fn build_playback(device: cpal::Device, mixer: AudioMixer) -> Result<AudioPlayback> {
+    let supported = device.default_output_config()?;
+    let config = StreamConfig {
+        channels: 1,
+        sample_rate: SampleRate(SAMPLE_RATE),
+        buffer_size: cpal::BufferSize::Default,
+    };
+    AudioPlayback::new(device, config, supported.sample_format(), mixer).await
 }

--- a/apps/tauri/haven-voice/src/protocol.rs
+++ b/apps/tauri/haven-voice/src/protocol.rs
@@ -1,0 +1,52 @@
+//! Newline-delimited JSON protocol between the Tauri shell and this sidecar.
+//!
+//! One JSON object per line, in both directions (see the `main.rs` header for
+//! the transport). Structured payloads (device lists, volume values, speaking
+//! rosters) don't fit the old plain-text `mute|unmute|leave` scheme, so the
+//! wire format is tagged JSON: `{"type":"mute"}`, `{"type":"connected"}`, etc.
+
+use serde::{Deserialize, Serialize};
+
+/// A control command from the Tauri app — one JSON object per stdin line.
+///
+/// `#[serde(tag = "type")]` gives the discriminated-union shape the TS bridge
+/// mirrors (`VoiceCommand`). Unknown commands fail to deserialize and are
+/// logged + ignored by the reader loop, so the sidecar never panics on garbage.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum Command {
+    /// Mute the local microphone track.
+    Mute,
+    /// Unmute the local microphone track.
+    Unmute,
+    /// Leave the room and shut the sidecar down.
+    Leave,
+    /// Switch the capture (microphone) device, keyed by cpal device name.
+    SetInputDevice { id: String },
+    /// Switch the playback (speaker) device, keyed by cpal device name.
+    SetOutputDevice { id: String },
+    /// Master playback gain, `0.0..=1.0`. Deafen sends `0.0`.
+    SetMasterVolume { value: f32 },
+    /// Per-participant playback gain, `0.0..=1.0`, keyed by LiveKit identity.
+    SetMemberVolume { identity: String, value: f32 },
+    /// Ask the sidecar to emit a `devices` event enumerating I/O devices.
+    EnumerateDevices,
+}
+
+/// A lifecycle/notification event to the Tauri app — one JSON object per
+/// stdout line, forwarded verbatim to the webview as a `voice://event`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum Event {
+    /// The room connection is established (pre track wiring).
+    Connected,
+    /// Capture + playback are wired and audio is flowing.
+    Ready,
+    /// The room closed (leave, parent gone, or connection lost).
+    Disconnected,
+    /// A non-fatal or fatal error, carrying a human-readable message.
+    Error { message: String },
+    // `Devices { inputs, outputs }` (device selection) and
+    // `Speaking { identities }` (speaking indicators) are added in their
+    // respective slices, so every intermediate build stays warning-clean.
+}

--- a/apps/tauri/haven-voice/src/protocol.rs
+++ b/apps/tauri/haven-voice/src/protocol.rs
@@ -46,7 +46,19 @@ pub enum Event {
     Disconnected,
     /// A non-fatal or fatal error, carrying a human-readable message.
     Error { message: String },
-    // `Devices { inputs, outputs }` (device selection) and
-    // `Speaking { identities }` (speaking indicators) are added in their
-    // respective slices, so every intermediate build stays warning-clean.
+    /// Available capture/playback devices, in response to `EnumerateDevices`.
+    Devices {
+        inputs: Vec<DeviceInfo>,
+        outputs: Vec<DeviceInfo>,
+    },
+    // `Speaking { identities }` (speaking indicators) is added in its slice, so
+    // every intermediate build stays warning-clean.
+}
+
+/// One selectable audio device. `id` is the cpal device name — cpal exposes no
+/// stable hardware id, but the name is stable enough to re-select in-session.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeviceInfo {
+    pub id: String,
+    pub label: String,
 }

--- a/apps/tauri/haven-voice/src/protocol.rs
+++ b/apps/tauri/haven-voice/src/protocol.rs
@@ -51,8 +51,9 @@ pub enum Event {
         inputs: Vec<DeviceInfo>,
         outputs: Vec<DeviceInfo>,
     },
-    // `Speaking { identities }` (speaking indicators) is added in its slice, so
-    // every intermediate build stays warning-clean.
+    /// Identities currently speaking (drives the Linux speaking indicators).
+    /// Identity == Haven user id, so it maps straight onto the roster.
+    Speaking { identities: Vec<String> },
 }
 
 /// One selectable audio device. `id` is the cpal device name — cpal exposes no

--- a/apps/tauri/src-tauri/.gitignore
+++ b/apps/tauri/src-tauri/.gitignore
@@ -1,2 +1,4 @@
 /target
 /gen/schemas
+# Staged haven-voice sidecar (built by tooling/scripts/stage-haven-voice-sidecar.mjs).
+/binaries

--- a/apps/tauri/src-tauri/src/voice.rs
+++ b/apps/tauri/src-tauri/src/voice.rs
@@ -26,13 +26,28 @@ struct VoiceProc {
     stdin: ChildStdin,
 }
 
-/// Resolve the haven-voice binary. `HAVEN_VOICE_BIN` overrides; otherwise look
-/// next to the app under apps/tauri/haven-voice/target/{debug,release}.
+/// Resolve the haven-voice binary, in priority order:
+///  1. `HAVEN_VOICE_BIN` env override (standalone / `cargo run` testing).
+///  2. Bundled sidecar next to the app exe — Tauri strips the target-triple
+///     suffix from the `externalBin` entry in packaged builds (see
+///     tauri.linux.conf.json), so it lands as plain `haven-voice`.
+///  3. Dev tree: the sidecar's own cargo target dir (a plain `cargo build` in
+///     apps/tauri/haven-voice, which is how we build it during development).
+///  4. Bare name, relying on PATH.
 fn voice_bin() -> std::path::PathBuf {
     if let Ok(p) = std::env::var("HAVEN_VOICE_BIN") {
         return std::path::PathBuf::from(p);
     }
+    let exe_name = if cfg!(windows) { "haven-voice.exe" } else { "haven-voice" };
     if let Ok(exe) = std::env::current_exe() {
+        // 2. Bundled sidecar: sits directly beside the app executable.
+        if let Some(dir) = exe.parent() {
+            let bundled = dir.join(exe_name);
+            if bundled.exists() {
+                return bundled;
+            }
+        }
+        // 3. Dev tree.
         // exe = .../apps/tauri/src-tauri/target/<profile>/haven-tauri
         // ancestors: [1]=<profile> [2]=target [3]=src-tauri [4]=apps/tauri
         if let Some(apps_tauri) = exe.ancestors().nth(4) {
@@ -41,7 +56,7 @@ fn voice_bin() -> std::path::PathBuf {
                     .join("haven-voice")
                     .join("target")
                     .join(profile)
-                    .join("haven-voice");
+                    .join(exe_name);
                 if candidate.exists() {
                     return candidate;
                 }

--- a/apps/tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/tauri/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "externalBin": ["binaries/haven-voice"]
+  }
+}

--- a/apps/tauri/src/bridge.ts
+++ b/apps/tauri/src/bridge.ts
@@ -8,6 +8,7 @@ import type {
   PopoutOptions,
   StagedUpdate,
   Platform,
+  VoiceEvent,
 } from "@solid-client/bridge";
 
 /**
@@ -63,20 +64,26 @@ export const tauriBridge: HavenBridge = {
   platform: detectPlatform(),
 
   // Native voice sidecar — only meaningful on Linux (WebKitGTK has no WebRTC),
-  // but harmless to expose everywhere; VoiceProvider gates on platform.
+  // but harmless to expose everywhere; VoiceProvider gates on platform. The
+  // sidecar speaks newline-delimited JSON, so commands are stringified and
+  // events are parsed here — the Solid UI only sees typed VoiceEvents.
   voice: {
     join: (serverUrl: string, token: string) =>
       invoke<void>("voice_join", { url: serverUrl, token }),
     setMuted: (muted: boolean) =>
       invoke<void>("voice_send_command", {
-        command: muted ? "mute" : "unmute",
+        command: JSON.stringify({ type: muted ? "mute" : "unmute" }),
       }),
     leave: () => invoke<void>("voice_leave"),
-    onEvent: async (handler: (event: string) => void) => {
+    onEvent: async (handler: (event: VoiceEvent) => void) => {
       const { listen } = await import("@tauri-apps/api/event");
-      return await listen<string>("voice://event", (event) =>
-        handler(event.payload),
-      );
+      return await listen<string>("voice://event", (event) => {
+        try {
+          handler(JSON.parse(event.payload) as VoiceEvent);
+        } catch {
+          // Ignore malformed lines rather than tearing down the listener.
+        }
+      });
     },
   },
 

--- a/apps/tauri/src/bridge.ts
+++ b/apps/tauri/src/bridge.ts
@@ -74,6 +74,18 @@ export const tauriBridge: HavenBridge = {
       invoke<void>("voice_send_command", {
         command: JSON.stringify({ type: muted ? "mute" : "unmute" }),
       }),
+    enumerateDevices: () =>
+      invoke<void>("voice_send_command", {
+        command: JSON.stringify({ type: "enumerateDevices" }),
+      }),
+    setInputDevice: (id: string) =>
+      invoke<void>("voice_send_command", {
+        command: JSON.stringify({ type: "setInputDevice", id }),
+      }),
+    setOutputDevice: (id: string) =>
+      invoke<void>("voice_send_command", {
+        command: JSON.stringify({ type: "setOutputDevice", id }),
+      }),
     leave: () => invoke<void>("voice_leave"),
     onEvent: async (handler: (event: VoiceEvent) => void) => {
       const { listen } = await import("@tauri-apps/api/event");

--- a/apps/tauri/src/bridge.ts
+++ b/apps/tauri/src/bridge.ts
@@ -86,6 +86,10 @@ export const tauriBridge: HavenBridge = {
       invoke<void>("voice_send_command", {
         command: JSON.stringify({ type: "setOutputDevice", id }),
       }),
+    setMasterVolume: (value: number) =>
+      invoke<void>("voice_send_command", {
+        command: JSON.stringify({ type: "setMasterVolume", value }),
+      }),
     leave: () => invoke<void>("voice_leave"),
     onEvent: async (handler: (event: VoiceEvent) => void) => {
       const { listen } = await import("@tauri-apps/api/event");

--- a/apps/tauri/src/bridge.ts
+++ b/apps/tauri/src/bridge.ts
@@ -90,6 +90,10 @@ export const tauriBridge: HavenBridge = {
       invoke<void>("voice_send_command", {
         command: JSON.stringify({ type: "setMasterVolume", value }),
       }),
+    setMemberVolume: (identity: string, value: number) =>
+      invoke<void>("voice_send_command", {
+        command: JSON.stringify({ type: "setMemberVolume", identity, value }),
+      }),
     leave: () => invoke<void>("voice_leave"),
     onEvent: async (handler: (event: VoiceEvent) => void) => {
       const { listen } = await import("@tauri-apps/api/event");

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Small on purpose — a handful of living documents plus one detailed-contract fo
 - [HAVEN_CORE.md](./architecture/HAVEN_CORE.md) — the data-layer contract: core, caches/nexuses, host boundaries, enforcement. The Solid core mirrors it.
 - [SOLID_CLIENT_SHAPE.md](./architecture/SOLID_CLIENT_SHAPE.md) — the desktop/web client's shape law: feature slices, routes, layering boundaries.
 - [REALTIME.md](./architecture/REALTIME.md) — the realtime event contract and coverage matrix.
+- [NATIVE_VOICE.md](./architecture/NATIVE_VOICE.md) — the Linux native voice sidecar: its seam, the stdio protocol, and the unreleased libwebrtc pin (with the watch/upgrade procedure).
 - [nexus-framework.html](./architecture/nexus-framework.html) — standalone visual walkthrough of the Nexus architecture (open in a browser).
 
 ## Rules for these docs

--- a/docs/architecture/NATIVE_VOICE.md
+++ b/docs/architecture/NATIVE_VOICE.md
@@ -1,0 +1,156 @@
+# Native voice (Linux) — the sidecar, its seam, and the WebRTC pin
+
+Maintained alongside [SOLID_CLIENT_SHAPE.md](./SOLID_CLIENT_SHAPE.md). Voice on
+desktop normally runs in-webview via `livekit-client`. **Linux can't** —
+WebKitGTK ships no WebRTC — so on Linux we run a native Rust sidecar
+(`apps/tauri/haven-voice`) that does the media, and the UI drives it through one
+seam. This doc is the contract for that sidecar and, critically, for the
+**unreleased libwebrtc pin** it depends on.
+
+## Why a sidecar
+
+- WebKitGTK (the Linux Tauri webview) has no WebRTC, so `livekit-client` cannot
+  connect from the webview. mac (WKWebView) and Windows (WebView2) can, and the
+  browser build can, so **only Linux** needs the sidecar today.
+- Running media in a separate process also isolates crashes: a libwebrtc fault
+  takes down the sidecar, not the app. The Tauri app never links libwebrtc.
+
+## The seam (single extension point)
+
+The UI never knows about the sidecar's internals. Everything flows through the
+`VoiceBridge` capability:
+
+```
+useVoice() / VoiceProvider (packages/solid-client/src/contexts/VoiceProvider.tsx)
+        │  gated by  bridge.platform === "linux"  ->  bridge.voice
+        ▼
+VoiceBridge  (contexts/BridgeProvider.tsx)          ← the seam; extend HERE
+        │  implemented by
+        ▼
+tauriBridge.voice  (apps/tauri/src/bridge.ts)       ← invoke() ⇄ Rust commands
+        │  stdio (newline-delimited JSON)
+        ▼
+voice.rs commands  (apps/tauri/src-tauri/src/voice.rs)   ← spawn / drive / kill
+        │  stdin: commands       stdout: events
+        ▼
+haven-voice sidecar  (apps/tauri/haven-voice/src/*)  ← LiveKit + cpal + libwebrtc
+```
+
+**Rule: new voice capability extends `VoiceBridge` and the JSON protocol — it
+does not add a new abstraction.** The web/mac/win path stays on the in-webview
+`Room`; the Linux path routes the same `useVoice()` action to `bridge.voice`.
+
+### The stdio protocol
+
+Newline-delimited JSON, one tagged object per line, defined in
+`apps/tauri/haven-voice/src/protocol.rs` and mirrored by `VoiceEvent` /
+`VoiceBridge` in `BridgeProvider.tsx`.
+
+| Direction                | Messages                                                                                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| UI → sidecar (`Command`) | `mute`, `unmute`, `leave`, `enumerateDevices`, `setInputDevice{id}`, `setOutputDevice{id}`, `setMasterVolume{value}`, `setMemberVolume{identity,value}` |
+| sidecar → UI (`Event`)   | `connected`, `ready`, `disconnected`, `error{message}`, `devices{inputs,outputs}`, `speaking{identities}`                                               |
+
+Identity keys (`setMemberVolume`, `speaking`) are the **Haven user id** — the
+voice-token function mints the LiveKit participant identity as the user id, so
+sidecar identities map straight onto the UI's `memberVolumes` / roster.
+
+### Feature parity notes
+
+- **Roster & speaking:** there's no in-webview `Room` on Linux, so the roster is
+  driven by the Supabase presence channel (`voiceSolidNexus.syncRoster`), and
+  speaking is overlaid from the sidecar's `speaking` event
+  (`VoiceSolidNexus.setSpeakingIds`). Reconcile-by-userId keeps `<For>` row
+  identity stable — this is what keeps the WebKitGTK DOM tree valid.
+- **Devices / volume / deafen:** the sidecar rebuilds its cpal capture/playback
+  streams on device switch (channels + mixer stay stable), applies per-member
+  gain before the mixer, and uses the mixer's master gain for deafen.
+- **Audio is mono.** Voice is mono; LiveKit downmixes received audio to mono and
+  DTX is mono-only. Do not "upgrade" the sidecar to stereo for voice.
+
+### Known duplication (do not merge yet, just know)
+
+`HavenBridge.voice` (this seam) and
+`packages/shared/src/infrastructure/platform/appHost.ts`
+(`VoiceRuntimeBridge` / `enumerateDevices`, the mobile/shared platform surface)
+are two overlapping "voice bridge" concepts. The desktop native path uses the
+`VoiceBridge` seam, not `VoiceRuntimeBridge`. If a third surface ever needs the
+sidecar, consolidate them then — not before.
+
+## The WebRTC / libwebrtc pin ⚠️
+
+This is the one dependency in the repo that needs **active watching**.
+
+### What is pinned, and why
+
+`apps/tauri/haven-voice/Cargo.toml` depends on `livekit` via **git**, not
+crates.io:
+
+```toml
+livekit = { git = "https://github.com/livekit/rust-sdks",
+            rev = "3dafb1d8e8fc49b907a7c4a74cf342dfcbb24c4f",
+            features = ["rustls-tls-native-roots"] }
+```
+
+The crates.io release of `livekit` pulls **libwebrtc 0.3.38**, which has a 3-arg
+`store_frame_metadata` while `webrtc-sys 0.3.36` expects 4 — an ABI mismatch
+across the FFI boundary that fails to build. The fix, **libwebrtc 0.3.39**, only
+exists in LiveKit's git tree (unreleased on crates.io at time of writing), so we
+pin the exact rev that provides an internally consistent set.
+
+### The compatible set (all from that one rev)
+
+| Crate              | Version                 |
+| ------------------ | ----------------------- |
+| `livekit`          | 0.7.50                  |
+| `livekit-api`      | 0.5.4                   |
+| `livekit-protocol` | 0.7.10                  |
+| `libwebrtc`        | **0.3.39** (unreleased) |
+| `webrtc-sys`       | 0.3.36                  |
+| `webrtc-sys-build` | 0.3.18                  |
+
+They resolve from the single git rev, so they cannot drift apart as long as the
+rev pin and the committed `apps/tauri/haven-voice/Cargo.lock` are kept.
+
+### Risk surface
+
+- **Blast radius is contained.** Only `haven-voice` links libwebrtc. The Tauri
+  app, mobile, and web never do. Today the sidecar ships **Linux only**
+  (`tauri.linux.conf.json` `externalBin`), so mac/win users are unaffected.
+- **Build needs network + a C++ toolchain.** `webrtc-sys-build` downloads a
+  prebuilt libwebrtc over HTTPS from a Google-hosted origin
+  (`chromium.googlesource.com`) at build time, and `webrtc-sys` compiles a C++
+  shim (needs `pkg-config`, a C++ compiler). cpal needs `libasound2-dev` on
+  Linux. CI installs these; see `.github/workflows/{ci,release-desktop}.yml`.
+- **Reproducibility depends on those hosts staying up** and the rev staying
+  reachable. The committed `Cargo.lock` locks resolution; `cargo build --locked`
+  in the `sidecar` CI job proves it stays consistent.
+
+### Upgrade / watch procedure
+
+Do **not** bump `livekit` casually — a naive bump can reintroduce the exact
+0.3.38-vs-0.3.36 mismatch. When you touch it:
+
+1. **Watch for the drop:** the pin can go away once crates.io ships a `livekit`
+   release whose `libwebrtc` is ≥ 0.3.39 (or otherwise ABI-matched to its
+   `webrtc-sys`). Check the [rust-sdks releases](https://github.com/livekit/rust-sdks/releases)
+   and the libwebrtc version it pulls.
+2. Prefer moving **back to a crates.io version** (drop the `git`/`rev`) once (1)
+   holds — that removes the git-fetch + prebuilt-download fragility.
+3. If staying on git, bump the `rev` and **re-verify the whole set** builds from
+   scratch (`cargo build --locked` in `apps/tauri/haven-voice`) — never trust a
+   partial/cached build for a WebRTC bump.
+4. Commit the regenerated `Cargo.lock` in the same change.
+5. Run the full Linux voice pass (connect, mute, deafen, device switch,
+   per-member volume, speaking with a second participant) before shipping.
+
+## Where things live
+
+- Sidecar: `apps/tauri/haven-voice/src/{main,protocol,audio_capture,audio_mixer,audio_playback,db_meter}.rs`
+- Process host: `apps/tauri/src-tauri/src/voice.rs`
+- Bundling: `apps/tauri/src-tauri/tauri.linux.conf.json`,
+  `tooling/scripts/stage-haven-voice-sidecar.mjs`
+- Seam: `packages/solid-client/src/contexts/BridgeProvider.tsx`,
+  `apps/tauri/src/bridge.ts`
+- UI/session: `packages/solid-client/src/contexts/VoiceProvider.tsx`,
+  `packages/solid-client/src/data/voice/voiceSolidNexus.ts`

--- a/packages/solid-client/src/bridge.ts
+++ b/packages/solid-client/src/bridge.ts
@@ -16,4 +16,6 @@ export type {
   UpdaterControls,
   Platform,
   VoiceBridge,
+  VoiceEvent,
+  VoiceDeviceInfo,
 } from "./contexts/BridgeProvider";

--- a/packages/solid-client/src/contexts/BridgeProvider.tsx
+++ b/packages/solid-client/src/contexts/BridgeProvider.tsx
@@ -30,6 +30,26 @@ export type BridgeCapabilities = {
 
 export type Platform = "macos" | "windows" | "linux";
 
+/** One selectable audio device reported by the native sidecar. */
+export type VoiceDeviceInfo = {
+  /** cpal device name — stable enough to re-select within a session. */
+  id: string;
+  label: string;
+};
+
+/**
+ * A structured event from the native sidecar. The wire form is newline-
+ * delimited JSON (one object per line); this is the parsed shape, mirroring
+ * the sidecar's `protocol::Event`.
+ */
+export type VoiceEvent =
+  | { type: "connected" }
+  | { type: "ready" }
+  | { type: "disconnected" }
+  | { type: "error"; message: string }
+  | { type: "devices"; inputs: VoiceDeviceInfo[]; outputs: VoiceDeviceInfo[] }
+  | { type: "speaking"; identities: string[] };
+
 /**
  * Native voice, mediated by the shell. Present only where the webview can't do
  * WebRTC itself (Linux/WebKitGTK): the shell spawns a native LiveKit sidecar
@@ -44,10 +64,10 @@ export type VoiceBridge = {
   /** Leave the room and stop the sidecar. */
   leave(): Promise<void>;
   /**
-   * Subscribe to sidecar lifecycle lines: "connected" | "ready" |
-   * "disconnected" | "error <msg>". Resolves with an unsubscribe fn.
+   * Subscribe to structured sidecar events (parsed from the JSON protocol).
+   * Resolves with an unsubscribe fn.
    */
-  onEvent(handler: (event: string) => void): Promise<() => void>;
+  onEvent(handler: (event: VoiceEvent) => void): Promise<() => void>;
 };
 
 /** Native window controls, used to drive custom (frameless) chrome. */

--- a/packages/solid-client/src/contexts/BridgeProvider.tsx
+++ b/packages/solid-client/src/contexts/BridgeProvider.tsx
@@ -73,6 +73,11 @@ export type VoiceBridge = {
   /** Switch the playback (speaker) device by id (cpal device name). */
   setOutputDevice(id: string): Promise<void>;
   /**
+   * Set the master playback gain (0..1) — silences all incoming audio at 0.
+   * Deafen uses this.
+   */
+  setMasterVolume(value: number): Promise<void>;
+  /**
    * Subscribe to structured sidecar events (parsed from the JSON protocol).
    * Resolves with an unsubscribe fn.
    */

--- a/packages/solid-client/src/contexts/BridgeProvider.tsx
+++ b/packages/solid-client/src/contexts/BridgeProvider.tsx
@@ -64,6 +64,15 @@ export type VoiceBridge = {
   /** Leave the room and stop the sidecar. */
   leave(): Promise<void>;
   /**
+   * Ask the sidecar to enumerate audio devices. The result arrives
+   * asynchronously as a `devices` event on `onEvent`.
+   */
+  enumerateDevices(): Promise<void>;
+  /** Switch the capture (microphone) device by id (cpal device name). */
+  setInputDevice(id: string): Promise<void>;
+  /** Switch the playback (speaker) device by id (cpal device name). */
+  setOutputDevice(id: string): Promise<void>;
+  /**
    * Subscribe to structured sidecar events (parsed from the JSON protocol).
    * Resolves with an unsubscribe fn.
    */

--- a/packages/solid-client/src/contexts/BridgeProvider.tsx
+++ b/packages/solid-client/src/contexts/BridgeProvider.tsx
@@ -78,6 +78,11 @@ export type VoiceBridge = {
    */
   setMasterVolume(value: number): Promise<void>;
   /**
+   * Set one participant's playback gain (0..1), keyed by identity (the Haven
+   * user id the voice token mints). Per-member volume sliders use this.
+   */
+  setMemberVolume(identity: string, value: number): Promise<void>;
+  /**
    * Subscribe to structured sidecar events (parsed from the JSON protocol).
    * Resolves with an unsubscribe fn.
    */

--- a/packages/solid-client/src/contexts/VoiceProvider.tsx
+++ b/packages/solid-client/src/contexts/VoiceProvider.tsx
@@ -365,19 +365,17 @@ export function VoiceProvider(props: { children: JSX.Element }) {
         // LiveKit participant events live in the sidecar, not the webview.
         nativeUnsub?.();
         nativeUnsub = await native.onEvent((ev) => {
-          if (ev === "connected" || ev === "ready") {
+          if (ev.type === "connected" || ev.type === "ready") {
             core.voice.setVoiceConnected(true);
             core.voice.markConnected();
-          } else if (ev === "disconnected") {
+          } else if (ev.type === "disconnected") {
             core.voice.setVoiceConnected(false);
             if (!intentionalDisconnect) {
               core.voice.setJoined(false);
               setVoice({ joined: false, notice: "Voice disconnected." });
             }
-          } else if (ev.startsWith("error")) {
-            setVoice({
-              error: ev.slice("error".length).trim() || "Failed to join voice.",
-            });
+          } else if (ev.type === "error") {
+            setVoice({ error: ev.message || "Failed to join voice." });
           }
         });
         await native.join(serverUrl, token);

--- a/packages/solid-client/src/contexts/VoiceProvider.tsx
+++ b/packages/solid-client/src/contexts/VoiceProvider.tsx
@@ -393,6 +393,9 @@ export function VoiceProvider(props: { children: JSX.Element }) {
               "outputDevices",
               ev.outputs.map((d) => ({ deviceId: d.id, label: d.label })),
             );
+          } else if (ev.type === "speaking") {
+            // Overlay the sidecar's active speakers onto the presence roster.
+            core.voice.setSpeakingIds(ev.identities);
           }
         });
         await native.join(serverUrl, token);

--- a/packages/solid-client/src/contexts/VoiceProvider.tsx
+++ b/packages/solid-client/src/contexts/VoiceProvider.tsx
@@ -239,6 +239,13 @@ export function VoiceProvider(props: { children: JSX.Element }) {
   };
 
   const refreshInputDevices = async () => {
+    const native = nativeVoice();
+    if (native) {
+      // Native path: the sidecar replies with a `devices` event, handled by the
+      // onEvent subscriber in joinChannel (which fills inputDevices/outputDevices).
+      await native.enumerateDevices().catch(() => {});
+      return;
+    }
     try {
       const devices = await Room.getLocalDevices("audioinput");
       setVoice(
@@ -376,11 +383,23 @@ export function VoiceProvider(props: { children: JSX.Element }) {
             }
           } else if (ev.type === "error") {
             setVoice({ error: ev.message || "Failed to join voice." });
+          } else if (ev.type === "devices") {
+            // Sidecar device lists mirror the web path's {deviceId,label} shape.
+            setVoice(
+              "inputDevices",
+              ev.inputs.map((d) => ({ deviceId: d.id, label: d.label })),
+            );
+            setVoice(
+              "outputDevices",
+              ev.outputs.map((d) => ({ deviceId: d.id, label: d.label })),
+            );
           }
         });
         await native.join(serverUrl, token);
         if (generation !== joinGeneration) return;
         await native.setMuted(voice.isMuted);
+        // Populate the device pickers (arrives async as a `devices` event).
+        void refreshInputDevices();
       } else {
         if (!room) room = createRoom();
         await room.connect(serverUrl, token, { autoSubscribe: true });
@@ -499,12 +518,16 @@ export function VoiceProvider(props: { children: JSX.Element }) {
 
   const switchInputDevice = async (deviceId: string) => {
     setVoice({ selectedInputDeviceId: deviceId });
-    await room?.switchActiveDevice("audioinput", deviceId).catch(() => {});
+    const native = nativeVoice();
+    if (native) await native.setInputDevice(deviceId).catch(() => {});
+    else await room?.switchActiveDevice("audioinput", deviceId).catch(() => {});
   };
 
   const setOutputDevice = async (deviceId: string) => {
     setVoice({ selectedOutputDeviceId: deviceId });
-    await room?.switchActiveDevice("audiooutput", deviceId).catch(() => {});
+    const native = nativeVoice();
+    if (native) await native.setOutputDevice(deviceId).catch(() => {});
+    else await room?.switchActiveDevice("audiooutput", deviceId).catch(() => {});
   };
 
   const enableAudioPlayback = async () => {

--- a/packages/solid-client/src/contexts/VoiceProvider.tsx
+++ b/packages/solid-client/src/contexts/VoiceProvider.tsx
@@ -500,8 +500,9 @@ export function VoiceProvider(props: { children: JSX.Element }) {
     core.voice.setIsDeafened(next);
     const native = nativeVoice();
     if (native) {
-      // The sidecar has no per-remote volume yet, so deafen at least mutes the
-      // mic; silencing others is a follow-up (needs a sidecar volume command).
+      // Deafen silences all incoming audio via the sidecar's master volume and
+      // (mirroring mobile) also mutes the mic; un-deafen restores playback.
+      void native.setMasterVolume(next ? 0 : 1).catch(() => {});
       if (next) void native.setMuted(true).catch(() => {});
     } else {
       applyRemoteVolumes(next);

--- a/packages/solid-client/src/contexts/VoiceProvider.tsx
+++ b/packages/solid-client/src/contexts/VoiceProvider.tsx
@@ -514,7 +514,13 @@ export function VoiceProvider(props: { children: JSX.Element }) {
   const setMemberVolume = (userId: string, volume: number) => {
     const clamped = Math.max(0, Math.min(100, Math.round(volume)));
     setVoice("memberVolumes", userId, clamped);
-    applyRemoteVolumes(voice.isDeafened);
+    const native = nativeVoice();
+    if (native) {
+      // Sidecar gain is 0..1, capped at 1 like the web path's setVolume.
+      void native.setMemberVolume(userId, Math.min(1, clamped / 100)).catch(() => {});
+    } else {
+      applyRemoteVolumes(voice.isDeafened);
+    }
   };
 
   const switchInputDevice = async (deviceId: string) => {

--- a/packages/solid-client/src/data/voice/voiceSolidNexus.ts
+++ b/packages/solid-client/src/data/voice/voiceSolidNexus.ts
@@ -99,6 +99,9 @@ export class VoiceSolidNexus {
   private kickConnectionSerial = 0;
   private presenceChannel: VoiceRealtimeChannel | null = null;
   private presenceConnectionSerial = 0;
+  // Live speaking set (native/Linux path). Presence carries the roster but not
+  // per-frame speaking, so the sidecar's ActiveSpeakersChanged is overlaid here.
+  private speakingIds = new Set<string>();
 
   constructor(
     viewerPolicyStore: ViewerMessagePolicyStore,
@@ -136,6 +139,8 @@ export class VoiceSolidNexus {
   }
 
   startConnect(channel: VoiceChannelReference): void {
+    // Fresh session — drop any speaking overlay from the previous channel.
+    this.speakingIds.clear();
     // Seed the LiveKit-source roster from the presence roster we already have so
     // the active-channel row doesn't blink empty during "connecting" (LiveKit is
     // empty until the room connects). applyParticipants reconciles it to the real
@@ -235,6 +240,28 @@ export class VoiceSolidNexus {
     this.setState(
       "participants",
       reconcile(participants, { key: "userId" }),
+    );
+  }
+
+  /**
+   * Overlay the live speaking set onto the active-channel roster (native/Linux
+   * path — the sidecar forwards LiveKit's active speakers). Re-applies over the
+   * current presence-driven roster; reconcile-by-userId keeps row identity so
+   * indicators flip without tearing down the row.
+   */
+  setSpeakingIds(identities: string[]): void {
+    const next = new Set(identities);
+    if (
+      next.size === this.speakingIds.size &&
+      [...next].every((id) => this.speakingIds.has(id))
+    )
+      return;
+    this.speakingIds = next;
+    this.setParticipants(
+      this.state.participants.map((participant) => ({
+        ...participant,
+        isSpeaking: next.has(participant.userId),
+      })),
     );
   }
 
@@ -407,9 +434,13 @@ export class VoiceSolidNexus {
       // arrays each time (setParticipants reconciles by userId) — never aliased.
       const syncRoster = () => {
         this.setParticipants(
-          normalizePresenceRows(channel.presenceState()).filter(
-            (participant) => participant.userId !== input.currentUserId,
-          ),
+          normalizePresenceRows(channel.presenceState())
+            .filter((participant) => participant.userId !== input.currentUserId)
+            // Preserve the live speaking overlay across presence syncs.
+            .map((participant) => ({
+              ...participant,
+              isSpeaking: this.speakingIds.has(participant.userId),
+            })),
         );
       };
       channel

--- a/tooling/scripts/stage-haven-voice-sidecar.mjs
+++ b/tooling/scripts/stage-haven-voice-sidecar.mjs
@@ -1,0 +1,48 @@
+// Build the haven-voice native voice sidecar and stage it where Tauri's
+// bundler expects an `externalBin` (see apps/tauri/src-tauri/tauri.linux.conf.json).
+//
+// Tauri requires the binary to carry a `-<target-triple>` suffix at bundle time
+// (it strips the suffix when placing it next to the app exe in the package).
+// This script builds the sidecar's standalone workspace, discovers the host
+// triple from rustc, and copies the artifact to
+//   apps/tauri/src-tauri/binaries/haven-voice-<triple>[.exe]
+//
+// Usage:
+//   node tooling/scripts/stage-haven-voice-sidecar.mjs           # release
+//   node tooling/scripts/stage-haven-voice-sidecar.mjs --debug   # debug
+//
+// Run this before `tauri build` / `tauri dev` on Linux (CI does this on the
+// Linux leg of release-desktop.yml). It's a no-op contract on other platforms
+// today — the sidecar only bundles on Linux until desktop unification lands.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, copyFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const sidecarDir = join(repoRoot, "apps", "tauri", "haven-voice");
+const binariesDir = join(repoRoot, "apps", "tauri", "src-tauri", "binaries");
+
+const profile = process.argv.includes("--debug") ? "debug" : "release";
+const cargoArgs = ["build", "--locked"];
+if (profile === "release") cargoArgs.push("--release");
+
+console.log(`[stage-sidecar] building haven-voice (${profile})…`);
+execFileSync("cargo", cargoArgs, { cwd: sidecarDir, stdio: "inherit" });
+
+// Host target triple, e.g. x86_64-unknown-linux-gnu.
+const rustcInfo = execFileSync("rustc", ["-vV"], { encoding: "utf8" });
+const tripleMatch = rustcInfo.match(/^host:\s*(.+)$/m);
+if (!tripleMatch) {
+  throw new Error("[stage-sidecar] could not determine host target triple from `rustc -vV`");
+}
+const triple = tripleMatch[1].trim();
+
+const ext = process.platform === "win32" ? ".exe" : "";
+const src = join(sidecarDir, "target", profile, `haven-voice${ext}`);
+const dest = join(binariesDir, `haven-voice-${triple}${ext}`);
+
+mkdirSync(binariesDir, { recursive: true });
+copyFileSync(src, dest);
+console.log(`[stage-sidecar] staged ${src} -> ${dest}`);


### PR DESCRIPTION
Brings the Linux native voice sidecar (`haven-voice`) from the working spike up to feature parity with the other desktop builds, and makes it stable to iterate on in lockstep. Built **sidecar-first** so it's ready if we later unify all desktop onto the sidecar (see the gated mac/win note below).

Targets `feat/native-voice` — this branch is exactly that branch's tip + the 7 commits below, so it merges cleanly and reviews as just the parity work. (A PR straight to `staging` conflicts on `package-lock.json`/`ci.yml` from the inherited #63/#64 dependency history — that reconciliation belongs to the native-voice→staging train, not here.)

## What's in it (slice by slice)

- **Slice 0 — JSON protocol.** Replaces the plain-text `mute|unmute|leave` stdio scheme with newline-delimited JSON (`protocol.rs` + typed `VoiceEvent`), the foundation the structured payloads need.
- **Slice 1 — ship the sidecar.** The pivotal gap: the sidecar shipped **nowhere** before (no `externalBin`, no CI build, dev-tree path). Now bundled Linux-only via `tauri.linux.conf.json`, staged by `tooling/scripts/stage-haven-voice-sidecar.mjs`, built in CI (release leg + a parallel `--locked` `sidecar` job).
- **Slice 2 — device selection.** cpal enumeration + rebuildable capture/playback streams; the mic/speaker pickers work on Linux instead of being no-ops. Stays mono.
- **Slice 3 — deafen.** Runtime-settable master gain in the mixer; deafen silences incoming audio, not just your own mic.
- **Slice 4 — per-member volume.** Per-identity gain applied before the mix; the sliders actually change audio.
- **Slice 5 — speaking indicators.** Sidecar forwards `ActiveSpeakersChanged`; overlaid on the presence-driven roster without breaking the WebKitGTK `<For>` fix.
- **Docs.** `docs/architecture/NATIVE_VOICE.md`: the reuse-seam contract and the full unreleased-libwebrtc pin watch/upgrade procedure.

## Design notes

- **One seam.** Every feature extends the single `VoiceBridge` capability + the JSON protocol — no new abstractions. The web/mac/win path stays on the in-webview `Room`.
- **Mono is intentional.** LiveKit downmixes received audio to mono and DTX is mono-only; documented so nobody "upgrades" it.
- **Desktop unification is gated.** Everything is sidecar-first, but flipping mac/win onto the sidecar is deliberately **not** in this PR — that's when the unreleased libwebrtc spreads to all desktop users and retires the working in-webview path there. Do it after Linux is stable.

## Verification

- TypeScript: `typecheck:solid` + eslint clean across all changed files; voice unit tests pass (4/4).
- Rust: **not compiled in this environment** — the sidecar's prebuilt libwebrtc host (`chromium.googlesource.com`) is egress-blocked here. The new CI `sidecar` job compiles it (and `--locked` proves the hand-updated `Cargo.lock`). Written carefully; a few LiveKit-API assumptions (`participant.identity()`, `RoomEvent::ActiveSpeakersChanged`) are worth a glance on the first green CI.
- Packaging (Slice 1) is untestable without a real tag build — best confirmed with a local `npm run tauri:build` on Linux.
- A full Linux voice pass (connect, mute, deafen, device switch, per-member volume, speaking with a 2nd participant) is planned before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cx7RfDPTTiqRxWhJFzT7uP)_