### PR TITLE
fix(voice): patch speaking in place — fix WebKitGTK "incorrect node tree" regression

### DIFF
--- a/packages/solid-client/src/data/voice/voiceSolidNexus.ts
+++ b/packages/solid-client/src/data/voice/voiceSolidNexus.ts
@@ -245,9 +245,15 @@ export class VoiceSolidNexus {
 
   /**
    * Overlay the live speaking set onto the active-channel roster (native/Linux
-   * path — the sidecar forwards LiveKit's active speakers). Re-applies over the
-   * current presence-driven roster; reconcile-by-userId keeps row identity so
-   * indicators flip without tearing down the row.
+   * path — the sidecar forwards LiveKit's active speakers).
+   *
+   * A speaking change is only ever a per-row boolean flip — never a membership
+   * add/remove/reorder — so it must NOT go through setParticipants/reconcile
+   * (the <For> structural path). Doing so raced with the presence-driven roster
+   * insert when joining a channel that already had members and reintroduced the
+   * WebKitGTK "incorrect node tree" crash. Patch isSpeaking in place instead:
+   * the array + row references never change, so <For> does zero structural work
+   * and only each row's isSpeaking signal updates.
    */
   setSpeakingIds(identities: string[]): void {
     const next = new Set(identities);
@@ -257,12 +263,12 @@ export class VoiceSolidNexus {
     )
       return;
     this.speakingIds = next;
-    this.setParticipants(
-      this.state.participants.map((participant) => ({
-        ...participant,
-        isSpeaking: next.has(participant.userId),
-      })),
-    );
+    this.state.participants.forEach((participant, index) => {
+      const speaking = next.has(participant.userId);
+      if (participant.isSpeaking !== speaking) {
+        this.setState("participants", index, "isSpeaking", speaking);
+      }
+    });
   }
 
   setChannelParticipants(


### PR DESCRIPTION
Fixes the WebKitGTK **"The operation would yield an incorrect node tree"** crash that came back on Linux when joining a voice channel that already has another member. Regression from the speaking-indicators slice (#65).

## Root cause
`voiceParticipantListsEqual` compares `isSpeaking`, so a speaking flip did **not** early-return in `setParticipants` — it ran `reconcile` over the whole roster. That made `setSpeakingIds` a **second roster-reconcile source** on top of the presence-driven one. LiveKit emits `ActiveSpeakersChanged` right as you connect, so on join-with-member-present that speaking reconcile raced with the presence roster **insert**, and WebKitGTK's stricter DOM threw the node-tree error (Chromium tolerated it). The original presence-roster fix (`030e6a3`) only made the *single* insert path safe; this reintroduced a competing one.

## Fix
A speaking change is only ever a per-row boolean flip — never a membership add/remove/reorder — so it must not go through the `<For>` structural path at all. `setSpeakingIds` now patches `isSpeaking` **in place** on the existing rows (`setState("participants", i, "isSpeaking", …)`), leaving the array and row references untouched: `<For>` does zero structural work, only each row's `isSpeaking` signal updates. `speakingIds` is still stored first, so a speaking event that arrives before the roster populates is picked up by the next presence sync. Membership changes still use the presence-driven reconcile as before.

## Verification
- `typecheck:solid` + eslint clean; voice unit tests pass (4/4).
- **Needs the Linux/WebKitGTK re-test to confirm** — the crash is WebKitGTK-specific and needs two participants, so it can't be reproduced in CI. The fix is targeted at the exact mechanism (removing the racing reconcile), but please re-run the "join a channel that already has someone in it" case.

Part of #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cx7RfDPTTiqRxWhJFzT7uP)_