### PR TITLE
Add maintainer agent handoff docs

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -23,10 +23,10 @@
 # SANITIZED PUBLIC test-signoff summary there — see docs/RELEASE_CADENCE.md). Never paste
 # raw test-reports/ logs; they're internal. Falls back to a generic body if the file is absent.
 #
-# Not handled here (deliberate, tracked separately): OS code signing —
-#   macOS notarization (Apple cert) and Windows Authenticode. Without them users
-#   get a Gatekeeper/SmartScreen prompt on first install, and unsigned macOS
-#   builds can hit Gatekeeper "damaged" errors on update. Updater (minisign)
+# OS signing status:
+#   macOS Developer ID signing + notarization is wired below through the Apple
+#   certificate and App Store Connect secrets. Windows Authenticode is not wired
+#   yet, so Windows users can still see SmartScreen prompts. Updater (minisign)
 #   signing above is independent of, and not a substitute for, OS code signing.
 
 name: Release Desktop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# Agent Handoff
+
+Haven is community chat for people who give a damn. Keep the product humane,
+private by construction, and easy for a tired maintainer to understand cold.
+When two correct options exist, choose the one you can explain plainly.
+
+This file is the quick index. Load the relevant project skill under
+`docs/agent-skills/` before changing code in that area.
+
+## First Moves
+
+- Treat `staging` as the integration truth. New feature/fix branches start from
+  `staging`, not `main`; promotion to `main` only happens after staged signoff.
+- Read [docs/PRINCIPLES.md](docs/PRINCIPLES.md) before architectural work.
+  The prime rule is understandable correctness.
+- Read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) before moving state,
+  adding shared logic, or changing app boundaries.
+- If code and docs disagree, the code wins and the docs are fixed in the same
+  change.
+- Keep generated local artifacts out of commits: `dist/`, `test-reports/`,
+  `.ota-export/`, `apps/mobile/ios/`, `apps/mobile/android/`,
+  Supabase `.temp/`, and Supabase generated test users are local-only.
+
+## Skill Index
+
+| Task                                                                                                               | Load this skill                                                                       |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| Starting, scoping, testing, or handing off any change                                                              | [haven-branch-ci-gates](docs/agent-skills/haven-branch-ci-gates/SKILL.md)             |
+| Changing `packages/shared`, backend clients, HavenCore contracts, realtime routing, or platform ports              | [haven-shared-core-boundary](docs/agent-skills/haven-shared-core-boundary/SKILL.md)   |
+| Adding or changing a desktop/web Solid feature, route, UI primitive, or popout                                     | [haven-solid-feature-slice](docs/agent-skills/haven-solid-feature-slice/SKILL.md)     |
+| Adding or changing a Solid data nexus/cache in `packages/solid-client/src/data`                                    | [haven-solid-nexus](docs/agent-skills/haven-solid-nexus/SKILL.md)                     |
+| Changing the Tauri desktop shell, bridge, capabilities, deep links, updater bridge, persistence, or popout windows | [haven-tauri-desktop-shell](docs/agent-skills/haven-tauri-desktop-shell/SKILL.md)     |
+| Changing desktop release workflow, updater signing, version sync, release notes, or packaged build behavior        | [haven-tauri-release](docs/agent-skills/haven-tauri-release/SKILL.md)                 |
+| Changing Tauri/sidecar Rust dependencies, Cargo locks, sidecar staging, or platform-specific lockfile churn        | [haven-tauri-cargo-lockfiles](docs/agent-skills/haven-tauri-cargo-lockfiles/SKILL.md) |
+| Changing the live Expo mobile app outside the chat keyboard shell                                                  | [haven-mobile-live-app](docs/agent-skills/haven-mobile-live-app/SKILL.md)             |
+| Changing mobile community/DM chat layout, composer clearance, or RNKC keyboard behavior                            | [haven-mobile-chat-surface](docs/agent-skills/haven-mobile-chat-surface/SKILL.md)     |
+| Changing Supabase migrations, RLS, RPCs, Edge Functions, fixtures, SQL tests, or backend contract tests            | [haven-supabase-rls](docs/agent-skills/haven-supabase-rls/SKILL.md)                   |
+| Changing Linux native voice, the Tauri voice process host, or the `VoiceBridge` protocol                           | [haven-native-voice-sidecar](docs/agent-skills/haven-native-voice-sidecar/SKILL.md)   |
+
+## Repo Map
+
+- `apps/mobile` - React Native + Expo app in active TestFlight use. React,
+  Expo, generated native projects, UniWind, and mobile-only native concerns live
+  here.
+- `apps/tauri` - Tauri v2 desktop shell and bootstrap for the shared Solid
+  client.
+- `apps/web` - Vite static web shell for the same Solid client.
+- `packages/shared` - portable domain logic, backend clients, shared types,
+  themes, and realtime routing. No React, no Solid, no platform cache.
+- `packages/solid-client` - Solid UI, Solid-native caches, desktop/web
+  composition root, and feature slices.
+- `supabase` - migrations, RLS policies, Edge Functions, fixtures, helpers, and
+  SQL regression suites.
+- `tooling` - repo checks, mobile wrappers, Supabase test runners, release
+  signoff/report scripts, and shared test support.
+
+## Guardrails That Matter
+
+- `npm run test:cleave` is the fast merge floor: lint, shared portability,
+  typecheck, mobile typecheck, mobile bundle smoke, and unit tests.
+- `npm run test:ci` adds `test:db` and `test:backend`; use it for DB/shared
+  behavior changes.
+- `npm run mobile:release:check` gates mobile release work.
+- `npm run check:themes` proves generated theme bridge outputs are current.
+- `npm run check:agent-skills` validates tracked agent skill frontmatter and
+  links without Python dependencies.
+- `cargo build --locked --manifest-path apps/tauri/haven-voice/Cargo.toml`
+  proves the Linux native voice sidecar still resolves and links.
+
+## Footguns To Avoid
+
+- Do not put permission decisions in UI. Security lives in Postgres RLS or
+  security-definer RPCs; clients reflect database truth.
+- Do not share reactive memory across frameworks. Share pure logic in
+  `packages/shared`; keep React and Solid caches per-platform.
+- Do not create Supabase clients, call RPCs, or open domain realtime channels in
+  UI/features. Use host bootstrap, HavenCore, backend clients, and nexuses.
+- Do not import features from other features in `packages/solid-client`.
+  Shared code moves down into `data/`, `components/ui/`, or `packages/shared`.
+- Do not add `@tauri-apps/*` to `packages/solid-client`; the Solid client must
+  run in Tauri and a plain browser tab.
+- Do not add root React/Expo dependencies or mobile Solid/Tauri dependencies.
+  `mobile:ownership` enforces the split.
+- Do not update one resolver for a path alias. Aliases are mirrored across
+  tsconfig, Babel, Metro, and Vitest until workspace package exports replace
+  them.
+- Do not edit generated mobile native folders as the source of truth. Edit Expo
+  config/plugins/templates, then prebuild.
+- Do not commit staged Tauri sidecar binaries from
+  `apps/tauri/src-tauri/binaries/`; that folder is generated for bundling and
+  gitignored.
+- Do not accept Cargo lockfile churn from the wrong platform without review.
+  Windows can prune Linux-only sidecar edges; Linux can add them back.
+- Do not split desktop release creation across matrix jobs. One draft release
+  is created up front and all platforms upload to its numeric id.
+- Do not ship a packaged Tauri build without `VITE_SUPABASE_URL` and
+  `VITE_SUPABASE_ANON_KEY` present at build time.
+
+## Known Rough Edges
+
+- Path aliases are an interim compatibility layer. The durable target is real
+  workspace packages with `exports`.
+- Some shared selectors still live under `@shared/nexus/*` while others live
+  under `@shared/features/*/logic`. Follow the existing domain imports; do not
+  consolidate as drive-by cleanup.
+- `revision` fields still exist in shared nexus state because mobile types need
+  them. Solid nexuses should initialize them but not read or increment them.
+- Realtime still has documented holes for reactions, attachments, and link
+  previews; see [docs/architecture/REALTIME.md](docs/architecture/REALTIME.md).
+- Desktop Linux voice has two overlapping bridge concepts (`VoiceBridge` and
+  `VoiceRuntimeBridge`). Use the documented `VoiceBridge` seam for the sidecar;
+  consolidate only when a real third surface needs it.
+- Desktop voice popout routing exists, but the launcher is hidden until
+  cross-window sync moves off BroadcastChannel and onto a Tauri-safe event path.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,11 @@ Small on purpose — a handful of living documents plus one detailed-contract fo
 - [NATIVE_VOICE.md](./architecture/NATIVE_VOICE.md) — the Linux native voice sidecar: its seam, the stdio protocol, and the unreleased libwebrtc pin (with the watch/upgrade procedure).
 - [nexus-framework.html](./architecture/nexus-framework.html) — standalone visual walkthrough of the Nexus architecture (open in a browser).
 
+## Agent handoff
+
+- [../AGENTS.md](../AGENTS.md) — quick index for future maintainers and coding agents.
+- [agent-skills/](./agent-skills/) — narrow, task-specific SKILL.md files for branch discipline, shared boundaries, Solid, Tauri desktop, mobile, Supabase, and native voice work.
+
 ## Rules for these docs
 
 - **A living doc is updated in the same change that invalidates it.** A doc that

--- a/docs/agent-skills/haven-branch-ci-gates/SKILL.md
+++ b/docs/agent-skills/haven-branch-ci-gates/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: haven-branch-ci-gates
+description: Use when starting, scoping, testing, finishing, or handing off any Haven repo change; covers branch base, staging-first workflow, package manager discipline, generated artifacts, CI lanes, and validation command selection.
+---
+
+# Haven Branch And CI Gates
+
+## Start Every Change
+
+1. Check the worktree first.
+   - `git status --short --branch`
+   - Do not overwrite user changes.
+2. Refresh remotes.
+   - `git fetch --all --prune`
+3. Base feature/fix/docs work on `staging`.
+   - `git switch staging`
+   - `git pull --ff-only origin staging`
+   - `git switch -c <type>/<short-name>`
+4. Do not merge `main` into feature work unless the release workflow explicitly
+   calls for it. `main` is promotion, not the day-to-day base.
+
+## Runtime And Install Discipline
+
+- Use Node 24. The repo pins this with `.nvmrc`, `.node-version`, CI, and
+  package engines.
+- Use npm, not pnpm or yarn. The root `packageManager` pins npm.
+- Use `npm ci` when lockfile correctness matters. Use `npm run setup:mobile` to
+  install the mobile tree.
+- If dependencies change, commit the matching lockfile:
+  `package-lock.json` for root and `apps/mobile/package-lock.json` for mobile.
+- Never commit local build or test outputs: `dist/`, `test-reports/`,
+  `.ota-export/`, `apps/mobile/ios/`, `apps/mobile/android/`, Supabase `.temp/`,
+  or generated local Supabase test users.
+
+## Pick The Gate By Blast Radius
+
+- Docs-only change:
+  - `npx prettier --check <changed-md-files>`
+- Agent handoff/skill change:
+  - `npm run check:agent-skills`
+- Shared/domain/Solid/mobile TS change:
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run mobile:typecheck` if shared or mobile can be affected
+  - `npm run test:unit` for cache, selector, utility, or UI logic changes
+- Fast merge floor:
+  - `npm run test:cleave`
+- DB/RLS/RPC/backend-contract change:
+  - `npm run test:db`
+  - `npm run test:backend`
+  - `npm run test:ci` before signoff
+- Mobile UI/native/release-sensitive change:
+  - `npm run mobile:preflight`
+  - `npm run check:mobile-uniwind`
+  - `npm run check:mobile-typography`
+  - `npm run mobile:typecheck`
+  - `npm run mobile:bundle`
+- Theme-token change:
+  - `npm run themes:generate`
+  - `npm run check:themes`
+- Native voice sidecar change:
+  - `cargo build --locked --manifest-path apps/tauri/haven-voice/Cargo.toml`
+
+## CI Shape
+
+- `fast` runs lint, shared portability, typecheck, and unit tests.
+- `mobile` runs ownership, preflight, Expo config, mobile typecheck, and bundle
+  smoke.
+- `integration` runs only when DB/shared/test harness inputs changed.
+- `sidecar` runs only when `apps/tauri/haven-voice/**` changed.
+- `gate` is the required aggregate check; skipped integration/sidecar lanes are
+  valid only when their path filters say they are unchanged.
+
+## Before Handoff
+
+- Run `git status --short --branch`.
+- State exactly which validation commands passed.
+- State which expected commands were not run and why.
+- Include doc updates in the same change when behavior or architecture changed.

--- a/docs/agent-skills/haven-mobile-chat-surface/SKILL.md
+++ b/docs/agent-skills/haven-mobile-chat-surface/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: haven-mobile-chat-surface
+description: Use when changing Haven mobile community chat or DM chat layout, ChatInterface, ChatComposer, inverted message lists, RNKC KeyboardChatScrollView, KeyboardStickyView, KeyboardGestureArea, composer clearance, extraContentPadding, safe-area math, blankSpace, or keyboard lift behavior.
+---
+
+# Haven Mobile Chat Surface
+
+## Golden Rule
+
+Screens compose `ChatInterface` and `ChatComposer`. All React Native Keyboard
+Controller layout belongs under `apps/mobile/src/components/chat/`.
+
+```tsx
+import { ChatComposer, ChatInterface } from "@/components/chat";
+
+<ChatInterface
+  data={items}
+  renderItem={renderItem}
+  keyboardScrollProps={{ keyboardLiftBehavior: "whenAtEnd" }}
+  composer={<ChatComposer {...composerProps} />}
+/>;
+```
+
+## Ownership
+
+| Layer            | File                                                          | Owns                                                                                               |
+| ---------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Shell            | `apps/mobile/src/components/chat/ChatInterface.tsx`           | Safe area, `KeyboardGestureArea`, `KeyboardStickyView`, inverted `FlatList`, `extraContentPadding` |
+| Scroll wrapper   | `apps/mobile/src/components/chat/internal/ChatScrollView.tsx` | The only direct `KeyboardChatScrollView` wrapper                                                   |
+| Constants        | `apps/mobile/src/components/chat/chatSurfaceConstants.ts`     | Composer min height, margin, list top padding formula                                              |
+| Composer UI      | `apps/mobile/src/components/chat/ChatComposer.tsx`            | Input chrome only                                                                                  |
+| Screens/features | community and DM screens                                      | Data, `renderItem`, composer props                                                                 |
+
+## Required Pattern
+
+- `SafeAreaView` bottom edge is owned by `ChatInterface`.
+- The list is inverted and wired inside `ChatInterface`.
+- Top padding is
+  `CHAT_COMPOSER_MIN_HEIGHT + CHAT_SURFACE_MARGIN`.
+- `extraContentPadding` is computed from sticky layout growth only:
+  multiline composer, reply strip, media strip.
+- `KeyboardChatScrollView` receives
+  `offset={bottom - CHAT_SURFACE_MARGIN}` inside `internal/ChatScrollView.tsx`.
+- `KeyboardGestureArea` uses `offset={CHAT_COMPOSER_MIN_HEIGHT}` and the shared
+  composer native id.
+- Composer bottom spacing is the chat surface margin inside the safe-area box.
+
+## Never Do These
+
+- Do not import `KeyboardChatScrollView` outside
+  `components/chat/internal/ChatScrollView.tsx`.
+- Do not place `KeyboardStickyView` or `KeyboardGestureArea` outside
+  `components/chat/`.
+- Do not use `blankSpace` for normal chat. It is for AI-streaming layouts, not
+  composer clearance.
+- Do not set screen-level `contentContainerStyle.paddingTop` for chat lists.
+- Do not subtract safe-area bottom manually from composer bottom when
+  `ChatInterface` already owns the bottom safe area.
+- Do not "fix" overlap by increasing magic padding. Fix the shell/constant
+  contract.
+
+## Validation
+
+- `npm run check:chat-surface`
+- `npm run mobile:typecheck`
+- `npm run mobile:bundle` when imports, navigation, or Metro resolution changed
+
+Use the debug tooling under
+`apps/mobile/src/components/chat/debug-tooling/` only during investigation.
+Remove temporary wiring before handoff.

--- a/docs/agent-skills/haven-mobile-live-app/SKILL.md
+++ b/docs/agent-skills/haven-mobile-live-app/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: haven-mobile-live-app
+description: Use when changing apps/mobile React Native or Expo code, mobile data nexuses, mobile navigation, UniWind styling, mobile native config/plugins, mobile dependencies, mobile commands, or mobile release-sensitive behavior.
+---
+
+# Haven Mobile Live App
+
+## Read Before Editing
+
+- [apps/mobile/README.md](../../../apps/mobile/README.md)
+- [docs/architecture/HAVEN_CORE.md](../../architecture/HAVEN_CORE.md)
+- [apps/mobile/docs/uniwind-mobile.md](../../../apps/mobile/docs/uniwind-mobile.md)
+- Load [haven-mobile-chat-surface](../haven-mobile-chat-surface/SKILL.md) when
+  touching chat list/composer/keyboard layout.
+
+## Production Posture
+
+The iOS app is live. Treat mobile data-layer and navigation changes as
+production-sensitive, even when the user asks for a small UI tweak.
+
+## Dependency Ownership
+
+- Mobile owns React, React Native, Expo, mobile native modules, UniWind, and
+  mobile-only native voice dependencies.
+- Root owns Solid, Tauri, Vite, shared tooling, and shared domain dependencies.
+- Do not add React/Expo packages to root `package.json`.
+- Do not add Solid/Tauri/Vite packages to `apps/mobile/package.json`.
+- Run `npm run mobile:ownership` when dependency ownership could be affected.
+
+## Data Access
+
+- Mobile constructs one `HavenReactCore` at app bootstrap.
+- UI reads domain state through `useHavenCore()` plus selector hooks from
+  `@mobile-data/hooks`.
+- UI writes call one core/cache command per gesture.
+- Feature code must not import backend factories, create Supabase clients, call
+  RPC/table/channel APIs directly, import persistence adapters, or open domain
+  realtime subscriptions.
+- `AuthContext` is the bounded auth/session exception, not a domain-data pattern.
+
+## Styling And Theme
+
+- Prefer UniWind `className` on React Native built-ins.
+- Use `*ClassName` props with `accent-*` for non-style color props such as
+  `color`, `tintColor`, and `placeholderTextColor`.
+- Use `ThemedIonicons` from `@/theme-rn` for semantic icon colors.
+- Do not add raw hex colors or raw Tailwind palette classes unless the guard has
+  an inline allow comment with a reason.
+- Run `npm run check:mobile-uniwind` after styling changes.
+
+## Native Generated Artifact Policy
+
+- `apps/mobile/ios/` and `apps/mobile/android/` are generated and gitignored.
+- Edit `app.json`, config plugins, and templates under `apps/mobile/plugins/`;
+  then run `npm run mobile:native:prebuild`.
+- For iOS delegate/native template work, run:
+  `node tooling/scripts/mobile/revalidate-ios-delegate.mjs`
+- Build local iOS from `HavenMobile.xcworkspace`, not the raw `.xcodeproj`.
+
+## Validation
+
+- `npm run mobile:preflight`
+- `npm run mobile:typecheck`
+- `npm run mobile:bundle`
+- `npm run check:mobile-uniwind` for styling/theme changes
+- `npm run check:mobile-typography` for text/type changes
+- `npm run test:unit` for data, utility, notification, or shared behavior
+- `npm run test:cleave` before merging mobile/shared work

--- a/docs/agent-skills/haven-native-voice-sidecar/SKILL.md
+++ b/docs/agent-skills/haven-native-voice-sidecar/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: haven-native-voice-sidecar
+description: Use when changing Linux native voice sidecar code, apps/tauri/haven-voice Rust, the Tauri process host, stage-haven-voice-sidecar tooling, VoiceBridge, voice stdio protocol, LiveKit Rust dependencies, libwebrtc pins, or Linux voice parity.
+---
+
+# Haven Native Voice Sidecar
+
+## Read Before Editing
+
+- [docs/architecture/NATIVE_VOICE.md](../../architecture/NATIVE_VOICE.md)
+- [packages/solid-client/src/contexts/BridgeProvider.tsx](../../../packages/solid-client/src/contexts/BridgeProvider.tsx)
+- [packages/solid-client/src/contexts/VoiceProvider.tsx](../../../packages/solid-client/src/contexts/VoiceProvider.tsx)
+- [apps/tauri/src/bridge.ts](../../../apps/tauri/src/bridge.ts)
+- [apps/tauri/src-tauri/src/voice.rs](../../../apps/tauri/src-tauri/src/voice.rs)
+- [apps/tauri/haven-voice/src/protocol.rs](../../../apps/tauri/haven-voice/src/protocol.rs)
+
+## Seam Rule
+
+Linux native voice flows through one seam:
+
+```text
+useVoice / VoiceProvider
+  -> BridgeProvider VoiceBridge
+  -> apps/tauri/src/bridge.ts
+  -> apps/tauri/src-tauri/src/voice.rs
+  -> apps/tauri/haven-voice stdio JSON protocol
+```
+
+Add capabilities by extending `VoiceBridge` and the newline-delimited JSON
+protocol. Do not add a second abstraction or a side path in UI.
+
+## Platform Rule
+
+- Linux uses the sidecar because WebKitGTK has no WebRTC.
+- macOS, Windows, and web stay in-webview with `livekit-client`.
+- The Tauri app does not link libwebrtc; only `apps/tauri/haven-voice` does.
+- Audio is mono for voice. Do not "upgrade" the sidecar to stereo.
+
+## Protocol Discipline
+
+- Commands and events are tagged JSON objects, one per line.
+- Keep protocol changes mirrored between Rust `protocol.rs`, TypeScript
+  `VoiceBridge`/`VoiceEvent`, and callers.
+- User identities are Haven user ids. Preserve that mapping for roster,
+  speaking, and per-member volume.
+- The popout is a mirror/remote control. It must not open its own LiveKit
+  connection.
+- The desktop popout launcher is intentionally hidden today. BroadcastChannel
+  does not reliably cross Tauri `WebviewWindow`s here; keep it hidden until sync
+  moves to a Tauri event-backed protocol.
+
+## Dependency Pin Discipline
+
+The sidecar currently pins LiveKit Rust to a git revision to get a compatible
+unreleased `libwebrtc` set.
+
+- Do not bump LiveKit casually.
+- Prefer returning to crates.io once a release pulls `libwebrtc >= 0.3.39` or an
+  otherwise ABI-compatible set.
+- If the git revision changes, verify from a clean build and commit the updated
+  `apps/tauri/haven-voice/Cargo.lock`.
+
+## Validation
+
+- `cargo fmt --manifest-path apps/tauri/haven-voice/Cargo.toml -- --check`
+- `cargo build --locked --manifest-path apps/tauri/haven-voice/Cargo.toml`
+- `node tooling/scripts/stage-haven-voice-sidecar.mjs --debug` when testing
+  Linux sidecar bundling/staging behavior locally
+- `cargo fmt --manifest-path apps/tauri/src-tauri/Cargo.toml -- --check` when
+  Tauri Rust host code changes
+- `cargo check --manifest-path apps/tauri/src-tauri/Cargo.toml` when Tauri Rust
+  host code changes
+- `npm run typecheck:solid` when TypeScript bridge/provider code changes
+
+Manual release confidence for Linux voice still requires connect, mute, deafen,
+device switch, per-member volume, and speaking tests with a second participant.

--- a/docs/agent-skills/haven-shared-core-boundary/SKILL.md
+++ b/docs/agent-skills/haven-shared-core-boundary/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: haven-shared-core-boundary
+description: Use when changing packages/shared, backend clients, shared domain logic, HavenCore contracts, RealtimeMutationTarget, routeRealtimeEvent, platform ports, persistence ports, themes, or any code that crosses mobile/Solid/web boundaries.
+---
+
+# Haven Shared Core Boundary
+
+## Read Before Editing
+
+- [docs/PRINCIPLES.md](../../PRINCIPLES.md)
+- [docs/ARCHITECTURE.md](../../ARCHITECTURE.md)
+- [docs/architecture/HAVEN_CORE.md](../../architecture/HAVEN_CORE.md)
+- [docs/architecture/REALTIME.md](../../architecture/REALTIME.md) when routing,
+  subscriptions, notifications, messages, DMs, social, moderation, or profile
+  events change.
+
+## The Law
+
+`packages/shared` is portable logic and contracts only.
+
+- Allowed: pure domain functions, backend interfaces/clients, shared types,
+  framework-free selectors, `zustand/vanilla`, persistence ports, platform ports,
+  theme token sources, realtime routing over typed interfaces.
+- Forbidden: React, Solid, React Native, DOM assumptions in portable paths,
+  platform caches, `createClient` call sites outside host bootstrap, direct env
+  reads for Supabase config, and hook-shaped `use*` exports under `shared/core`.
+
+Share the smarts, not the memory. A reactive store is never shared across React
+and Solid.
+
+## Put Code In The Canonical Home
+
+- Backend clients, RPC wrappers, and network shapes:
+  `packages/shared/src/lib/backend/`
+- Supabase client construction:
+  `packages/shared/src/lib/createHavenSupabaseClient.ts`
+- Domain logic:
+  `packages/shared/src/features/<domain>/`
+- Realtime routing:
+  `packages/shared/src/core/routeRealtimeEvent.ts`
+- Realtime platform contract:
+  `packages/shared/src/core/realtimeMutationTarget.ts`
+- Persistence ports:
+  `packages/shared/src/core/persistence/`
+- Pure selectors and entity state types:
+  `packages/shared/src/nexus/`
+- Platform capability port:
+  `packages/shared/src/infrastructure/platform/appHost.ts`
+- Theme token source:
+  `packages/shared/src/themes/`
+
+Do not create a second implementation. If a temporary import path must exist, it
+is a one-line shim with an expiry, not a copy.
+
+## Data-Layer Change Recipe
+
+1. Decide if the change is logic or cache.
+   - Logic is data in/data out and belongs in `packages/shared`.
+   - Cache holds reactive state and belongs to mobile or Solid data layers.
+2. Add or update backend interfaces before UI call sites.
+3. Add a HavenCore/cache command for UI writes. Do not let UI import backend
+   factories or call Supabase directly.
+4. Route new private-user realtime events in `routeRealtimeEvent` by patching,
+   evicting, or reloading one primary domain.
+5. Extend `RealtimeMutationTarget` only when shared routing genuinely needs a new
+   platform-core capability.
+6. Update both platform cores/caches when the shared contract changes.
+7. Update architecture docs in the same change if the contract changed.
+
+## Guardrails
+
+- `npm run check:shared-portable`
+- `npm run check:shared-hex`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run test:cleave` before merging shared changes
+- `npm run test:db` and `npm run test:backend` when backend/RLS behavior or
+  backend contracts changed
+
+## Footguns
+
+- Path aliases are mirrored across tsconfig, Metro, Babel, and Vitest. Do not
+  add or change one alias in isolation.
+- The shared selector home is not fully normalized yet. Follow the domain's
+  existing imports; save selector relocation for an explicit cleanup.
+- `revision` in shared nexus state is mobile compatibility. Solid code should
+  initialize it only.
+- The client anon key is public by design. Service-role behavior belongs only in
+  trusted Supabase/server contexts.

--- a/docs/agent-skills/haven-solid-feature-slice/SKILL.md
+++ b/docs/agent-skills/haven-solid-feature-slice/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: haven-solid-feature-slice
+description: Use when adding or changing desktop/web Solid features, routes, popout routes, UI primitives, shell-agnostic bridge usage, or package boundaries under packages/solid-client.
+---
+
+# Haven Solid Feature Slice
+
+## Read Before Editing
+
+- [docs/architecture/SOLID_CLIENT_SHAPE.md](../../architecture/SOLID_CLIENT_SHAPE.md)
+- [packages/solid-client/src/features/README.md](../../../packages/solid-client/src/features/README.md)
+- [packages/solid-client/src/routes/README.md](../../../packages/solid-client/src/routes/README.md)
+- [packages/solid-client/src/components/ui/README.md](../../../packages/solid-client/src/components/ui/README.md)
+
+## Layer Law
+
+Dependencies point down only:
+
+| Layer                     | May import                                           |
+| ------------------------- | ---------------------------------------------------- |
+| `App.tsx`                 | routes, contexts, core, UI primitives, root files    |
+| `routes/`                 | feature barrels, contexts, core, UI primitives       |
+| `features/*`              | data, UI primitives, contexts, auth, core, `@shared` |
+| `contexts/`               | core, auth, data                                     |
+| `auth/`                   | core                                                 |
+| `core/`                   | data                                                 |
+| `data/`, `components/ui/` | `@shared` and Solid only                             |
+
+Anything not allowed is a lint error by design.
+
+## Add Or Change A Feature
+
+1. Put the feature in `packages/solid-client/src/features/<feature-name>/`.
+2. Export the public surface from that feature's `index.ts`.
+3. Register routes in `packages/solid-client/src/routes/index.tsx`.
+4. Keep `App.tsx` untouched unless adding/removing app-wide providers or chrome.
+5. Keep shared visual primitives in `components/ui/` only when they have no data
+   access and no feature knowledge.
+6. Move shared feature logic down into `data/`, `components/ui/`, or
+   `packages/shared`; never import one feature from another.
+
+## Shell-Agnostic Rule
+
+`packages/solid-client` must run under Tauri and in a normal browser tab.
+
+- Do not import `@tauri-apps/*` in `packages/solid-client`.
+- Add shell capability to `bridge.ts` and implement it in `apps/tauri/src/bridge.ts`
+  and the browser/web fallback.
+- A popout is a route. Window creation/sizing belongs to `apps/tauri`; the Solid
+  app renders whatever route the shell points at.
+
+## Styling
+
+- Use semantic Tailwind utilities such as `bg-card`, `text-foreground`, and
+  `bg-surface-panel`.
+- Do not use raw primitive token classes like `bg-surface-2` unless the generated
+  bridge emits them.
+- Use `lucide-solid` for icons when a suitable icon exists.
+- Keep UI primitives dumb: props in, JSX out, no core/data imports.
+
+## Validation
+
+- `npm run typecheck:solid`
+- `npm run lint`
+- `npm run test:unit` when data projections, feature logic, or route behavior
+  changed
+- `npm run build:solid` when shell/bootstrap/build behavior changed

--- a/docs/agent-skills/haven-solid-nexus/SKILL.md
+++ b/docs/agent-skills/haven-solid-nexus/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: haven-solid-nexus
+description: Use when adding, converting, or changing Solid data nexuses/caches under packages/solid-client/src/data, HavenSolidCore wiring, Solid store projections, Solid realtime cache mutations, or data-layer tests.
+---
+
+# Haven Solid Nexus
+
+## Read Before Editing
+
+- [packages/solid-client/src/data/README.md](../../../packages/solid-client/src/data/README.md)
+- [packages/solid-client/src/data/NEXUS_RECIPE.md](../../../packages/solid-client/src/data/NEXUS_RECIPE.md)
+- [packages/solid-client/src/data/channels/channelSolidNexus.ts](../../../packages/solid-client/src/data/channels/channelSolidNexus.ts)
+- [docs/architecture/HAVEN_CORE.md](../../architecture/HAVEN_CORE.md)
+
+## Shape
+
+Each domain owns one `XxxSolidNexus`:
+
+```text
+packages/solid-client/src/data/<domain>/
+  <domain>SolidNexus.ts
+  index.ts
+```
+
+- File names are camelCase and use the full domain name.
+- Classes are PascalCase with a `SolidNexus` suffix.
+- Folder names mirror mobile domain names when the domain exists on both
+  platforms.
+- `HavenSolidCore` constructs and owns the nexus.
+
+## Non-Negotiable Store Rules
+
+- Use Solid `createStore` directly.
+- Read through projection methods that return tracked values or `createMemo`
+  accessors.
+- Write through named methods only.
+- Use path-based `setState("slot", key, value)` for mutations.
+- Keep `setState` private.
+- Never expose mutable store writers to UI.
+- Never spread a store proxy into a snapshot for reactive reads.
+- Never add `wireSolidReadableStore`, `fromStore`, manual `notify()`,
+  subscribe/tick scaffolding, equality wrappers, or revision increments.
+
+## Conversion Or Addition Procedure
+
+1. Scout the full public surface before editing:
+   - Feature usage under `packages/solid-client/src/features`
+   - `HavenSolidCore` calls
+   - `RealtimeMutationTarget` required method names
+   - Existing mobile nexus names for parity
+2. Preserve public method names expected by core/realtime contracts.
+3. Move pure projection logic to `@shared` when the logic must match mobile.
+4. Keep backend access behind injected backend interfaces.
+5. Add lifecycle methods (`load`, `ensureLoaded`, `rehydrate`, `clear`) only when
+   the domain actually needs them.
+6. Add tests beside the domain when projections, persistence, realtime patching,
+   or ordering behavior can regress.
+
+## Validation
+
+- `npm run typecheck:solid`
+- `npm run lint`
+- `npx vitest run packages/solid-client/src/data/<domain>` for domain tests
+- `npm run test:unit` before handoff if shared/mobile contracts are touched
+
+## Footguns
+
+- Solid's Node test environment needs the Vitest alias forcing `solid-js` to the
+  reactive dev build. Do not remove that alias while Solid data tests exist.
+- `revision` may appear in shared state types. Initialize it if the type requires
+  it; do not use it for Solid reactivity.
+- Do not add a Solid cache to `packages/shared`. The cache is platform memory.

--- a/docs/agent-skills/haven-supabase-rls/SKILL.md
+++ b/docs/agent-skills/haven-supabase-rls/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: haven-supabase-rls
+description: Use when changing Supabase migrations, Postgres RLS policies, security-definer RPCs, database triggers, realtime broadcasts, Edge Functions, SQL fixtures, SQL/RLS tests, backend contract tests, or Supabase generated types.
+---
+
+# Haven Supabase RLS
+
+## Read Before Editing
+
+- [docs/PRINCIPLES.md](../../PRINCIPLES.md), especially "Security lives in the
+  database"
+- [docs/ARCHITECTURE.md](../../ARCHITECTURE.md)
+- [supabase/tests/README.md](../../../supabase/tests/README.md)
+- [docs/architecture/REALTIME.md](../../architecture/REALTIME.md) when changing
+  private-user broadcasts or realtime-visible rows
+
+## Security Rule
+
+The client reflects what the database permits. It does not decide access.
+
+- Permission checks belong in RLS policies or security-definer RPCs.
+- The anon key is public by design.
+- Service-role secrets never ship to renderer/mobile/web clients.
+- Edge Functions must validate the caller's JWT and domain access before
+  returning privileged data such as voice tokens.
+
+## Migration Discipline
+
+- Add a new timestamped migration in `supabase/migrations/`.
+- Do not rewrite committed migrations unless the task is an explicit schema
+  reset.
+- Keep RLS policy changes and tests in the same PR.
+- For new RPCs, check grants. Revoke broad/default access first, then grant the
+  intended roles.
+- For new tables or private broadcasts, decide replica identity and realtime
+  publication deliberately.
+- Update backend contract types and generated Supabase types with
+  `npm run supabase:types` when schema shape changes.
+
+## Test Discipline
+
+The SQL suite runs against local Supabase via `psql`.
+
+- `npm run test:db` resets local DB, bootstraps auth users, loads fixtures, and
+  runs the SQL suite.
+- `npm run test:db:rls` assumes local Supabase is running and runs helpers,
+  fixtures, and SQL.
+- `npm run test:db:quick` assumes fixtures are already loaded.
+- `npm run test:backend` runs backend seam contract/integration tests.
+- Use `npm run test:ci` for DB/shared/backend behavior before signoff.
+
+## Where Tests Go
+
+- Deterministic reusable data:
+  `supabase/tests/fixtures/`
+- Assertion/auth helper functions:
+  `supabase/tests/_helpers/`
+- RLS/RPC regression suites:
+  `supabase/tests/sql/`
+- Backend client contract tests:
+  `packages/shared/src/lib/backend/__tests__/`
+
+## Realtime Changes
+
+1. Make the SQL trigger/broadcast emit the exact payload the client needs.
+2. Route the event in `packages/shared/src/core/routeRealtimeEvent.ts`.
+3. Extend `RealtimeMutationTarget` only when a new platform-core mutation surface
+   is necessary.
+4. Update [docs/architecture/REALTIME.md](../../architecture/REALTIME.md).
+5. Cover the SQL behavior and the TypeScript routing behavior.
+
+## Footguns
+
+- A green UI test does not prove access control. RLS tests do.
+- A direct client filter is not security.
+- A helper or fixture change is part of the integration test input surface; CI
+  intentionally runs DB/backend lanes for those paths.
+- Generated local Supabase files under `.temp/` and `.generated/` are not source
+  artifacts.

--- a/docs/agent-skills/haven-tauri-cargo-lockfiles/SKILL.md
+++ b/docs/agent-skills/haven-tauri-cargo-lockfiles/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: haven-tauri-cargo-lockfiles
+description: Use when changing Tauri Rust dependencies, Cargo.toml/Cargo.lock files, apps/tauri/src-tauri, apps/tauri/haven-voice, Rust toolchain/build commands, sidecar staging, platform-specific dependency resolution, or lockfile churn from Windows/Linux/macOS builds.
+---
+
+# Haven Tauri Cargo Lockfiles
+
+## Read Before Editing
+
+- [apps/tauri/src-tauri/Cargo.toml](../../../apps/tauri/src-tauri/Cargo.toml)
+- [apps/tauri/haven-voice/Cargo.toml](../../../apps/tauri/haven-voice/Cargo.toml)
+- [docs/architecture/NATIVE_VOICE.md](../../architecture/NATIVE_VOICE.md)
+- [tooling/scripts/stage-haven-voice-sidecar.mjs](../../../tooling/scripts/stage-haven-voice-sidecar.mjs)
+- [.github/workflows/ci.yml](../../../.github/workflows/ci.yml)
+- [.github/workflows/release-desktop.yml](../../../.github/workflows/release-desktop.yml)
+
+## Two Workspaces
+
+There are two independent Cargo workspaces:
+
+- Tauri app host:
+  - manifest: `apps/tauri/src-tauri/Cargo.toml`
+  - lockfile: `apps/tauri/src-tauri/Cargo.lock`
+- Linux native voice sidecar:
+  - manifest: `apps/tauri/haven-voice/Cargo.toml`
+  - lockfile: `apps/tauri/haven-voice/Cargo.lock`
+  - standalone `[workspace]` by design
+
+Do not merge the sidecar into the Tauri app workspace. It is isolated so
+libwebrtc and LiveKit Rust cannot leak into the app host or non-Linux bundles.
+
+## Lockfile Rule
+
+- Use `cargo build --locked` or `cargo check --locked` for verification.
+- Commit a Cargo.lock change only when the matching Cargo.toml or intentional
+  dependency update requires it.
+- Platform-only lockfile churn is not a feature change. Inspect it before
+  committing.
+- If Windows drops Linux-only sidecar dependencies or Linux adds them back, do
+  not bless the churn blindly. Regenerate/verify from the platform that owns the
+  dependency surface, usually Linux for `haven-voice`.
+
+## Platform Ownership
+
+- `src-tauri` is cross-platform Tauri host code.
+- `haven-voice` is Linux-shipped today, even though some dependencies have
+  platform entries in the lockfile.
+- Linux sidecar build needs ALSA, GTK/glib/WebKit stack libraries, pkg-config, a
+  C++ toolchain, network access to the LiveKit git rev, and the prebuilt
+  libwebrtc download host.
+- macOS and Windows release jobs should not stage `haven-voice`.
+
+## Sidecar Staging Contract
+
+`tooling/scripts/stage-haven-voice-sidecar.mjs`:
+
+1. Builds `apps/tauri/haven-voice` with `cargo build --locked`.
+2. Uses `rustc -vV` to discover the host target triple.
+3. Copies the binary to
+   `apps/tauri/src-tauri/binaries/haven-voice-<triple>[.exe]`.
+
+Tauri requires the target-triple suffix at bundle time and strips it at runtime.
+The staged `binaries/` directory is gitignored; never commit staged binaries.
+
+## Dependency Update Procedure
+
+1. Identify which workspace owns the dependency.
+2. Edit only that workspace's `Cargo.toml`.
+3. Run the narrow update from that workspace when possible.
+4. Run locked verification:
+   - `cargo check --locked --manifest-path apps/tauri/src-tauri/Cargo.toml`
+   - `cargo build --locked --manifest-path apps/tauri/haven-voice/Cargo.toml`
+     for sidecar changes
+5. Review `git diff -- apps/tauri/src-tauri/Cargo.lock apps/tauri/haven-voice/Cargo.lock`.
+6. Reject unrelated platform prune/add churn unless the dependency update truly
+   requires it.
+
+## WebRTC Pin
+
+The sidecar's `livekit` dependency is pinned to a git revision for an
+unreleased libwebrtc-compatible set. When that pin changes:
+
+- Verify `livekit`, `livekit-api`, `livekit-protocol`, `libwebrtc`,
+  `webrtc-sys`, and `webrtc-sys-build` still resolve as a compatible set.
+- Prefer returning to crates.io once LiveKit releases a compatible version.
+- Build from a clean sidecar target when possible. Cached success is not proof
+  for this dependency.
+- Commit the sidecar `Cargo.lock` in the same change if the pin changes.
+
+## Quick Diff Triage
+
+- `apps/tauri/src-tauri/Cargo.lock` changed but no `src-tauri/Cargo.toml`
+  dependency changed: suspect accidental toolchain/platform churn.
+- `apps/tauri/haven-voice/Cargo.lock` changed on Windows with no sidecar
+  dependency change: suspect Linux dependency pruning.
+- Both lockfiles changed for a JS-only desktop UI tweak: almost certainly
+  accidental.

--- a/docs/agent-skills/haven-tauri-desktop-shell/SKILL.md
+++ b/docs/agent-skills/haven-tauri-desktop-shell/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: haven-tauri-desktop-shell
+description: Use when changing the Haven Tauri desktop shell, apps/tauri bootstrap, Tauri config, capabilities, custom window chrome, deep links, updater bridge, persistence, popout windows, boot splash behavior, or shell-injected HavenBridge capabilities.
+---
+
+# Haven Tauri Desktop Shell
+
+## Read Before Editing
+
+- [docs/architecture/SOLID_CLIENT_SHAPE.md](../../architecture/SOLID_CLIENT_SHAPE.md)
+- [docs/architecture/NATIVE_VOICE.md](../../architecture/NATIVE_VOICE.md) for
+  voice or popout work
+- [apps/tauri/src/bridge.ts](../../../apps/tauri/src/bridge.ts)
+- [packages/solid-client/src/contexts/BridgeProvider.tsx](../../../packages/solid-client/src/contexts/BridgeProvider.tsx)
+- [apps/tauri/src-tauri/src/lib.rs](../../../apps/tauri/src-tauri/src/lib.rs)
+- [apps/tauri/src-tauri/tauri.conf.json](../../../apps/tauri/src-tauri/tauri.conf.json)
+- [apps/tauri/src-tauri/capabilities/default.json](../../../apps/tauri/src-tauri/capabilities/default.json)
+
+## Shell Boundary
+
+`packages/solid-client` is shell-agnostic. It must run in Tauri and in a plain
+browser tab.
+
+- Solid UI consumes `HavenBridge` from `@solid-client/bridge`.
+- Tauri implements that bridge in `apps/tauri/src/bridge.ts`.
+- Browser/web fallback lives in `BridgeProvider.tsx`.
+- Do not import `@tauri-apps/*` in `packages/solid-client`.
+- New shell capabilities extend `HavenBridge`; they do not become direct Tauri
+  imports in features.
+
+## Boot Contract
+
+- `apps/tauri/src/main.tsx` creates `HavenSolidCore` before rendering `<App>`.
+- `getTauriSupabaseConfig()` reads `VITE_SUPABASE_URL` and
+  `VITE_SUPABASE_ANON_KEY` at Vite build time.
+- Missing env values make packaged boot fail before the splash clears; the boot
+  catcher renders the error into the splash.
+- Release builds must provide those Vite envs in the desktop release workflow.
+- The splash is inline in `apps/tauri/index.html` and is removed before Solid
+  render. Do not mount UI over it.
+
+## Tauri Config Ownership
+
+- Base app, updater, deep link, and default window config:
+  `apps/tauri/src-tauri/tauri.conf.json`
+- Linux-only external sidecar binary:
+  `apps/tauri/src-tauri/tauri.linux.conf.json`
+- macOS titlebar, entitlements, and minimum OS:
+  `apps/tauri/src-tauri/tauri.macos.conf.json`
+- Native command/plugin wiring:
+  `apps/tauri/src-tauri/src/lib.rs`
+- Capability permissions:
+  `apps/tauri/src-tauri/capabilities/default.json`
+
+If a bridge method needs a Tauri permission, update capabilities in the same
+change.
+
+## Deep Links And Single Instance
+
+- `tauri-plugin-single-instance` must stay first in the builder chain.
+- Windows/Linux second launches forward `haven://` args through the
+  `deep-link-url` event.
+- macOS/plugin delivery uses `onOpenUrl`.
+- Cold start links are read through `getCurrent()`.
+- Keep all three paths when touching deep links.
+
+## Popout Windows
+
+- A popout is a route rendered in an OS viewport.
+- Window creation and sizing belong to the Tauri bridge.
+- Routes and UI remain in `packages/solid-client`.
+- `voice-popout` is listed in capabilities because it may receive bridge
+  permissions.
+- Current desktop voice popout is intentionally hidden. BroadcastChannel does
+  not reliably cross Tauri `WebviewWindow`s here; do not re-enable it until sync
+  moves to a Tauri event-backed protocol.
+
+## Persistence
+
+- Tauri persistence prefers `tauri-plugin-store` through
+  `createTauriPluginStorePersistence()`.
+- Browser dev or plugin failure falls back to shared localStorage persistence.
+- Nexus APIs are sync; the plugin-store adapter keeps an in-memory cache and
+  writes asynchronously.
+
+## Validation
+
+- `npm run typecheck:solid`
+- `npm run lint`
+- `npm run build:solid`
+- `cargo check --manifest-path apps/tauri/src-tauri/Cargo.toml` for Rust host
+  changes
+- `npm run tauri:build` when Tauri config, capabilities, bundle config, updater,
+  or release boot behavior changed

--- a/docs/agent-skills/haven-tauri-release/SKILL.md
+++ b/docs/agent-skills/haven-tauri-release/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: haven-tauri-release
+description: Use when changing Haven desktop release workflow, desktop versioning, Tauri updater config, release notes, GitHub draft release creation, signing/notarization, release-desktop.yml, desktop tags, or packaged Tauri build behavior.
+---
+
+# Haven Tauri Release
+
+## Read Before Editing
+
+- [docs/RELEASE_CADENCE.md](../../RELEASE_CADENCE.md)
+- [docs/releases/README.md](../../releases/README.md)
+- [.github/workflows/release-desktop.yml](../../../.github/workflows/release-desktop.yml)
+- [tooling/scripts/check-desktop-version-sync.mjs](../../../tooling/scripts/check-desktop-version-sync.mjs)
+- [apps/tauri/src-tauri/tauri.conf.json](../../../apps/tauri/src-tauri/tauri.conf.json)
+
+## Release Trigger
+
+- Desktop releases are triggered only by tags named `desktop-v<semver>`.
+- Tags are applied on a `release/*` branch cut from `main`.
+- The workflow creates a draft GitHub Release first, then matrix jobs upload
+  artifacts to that release by numeric `releaseId`.
+- Do not let matrix jobs create releases by tag. GitHub does not return drafts
+  from get-by-tag calls, which can create duplicate draft releases and split
+  `latest.json`.
+
+## Version Fields
+
+Keep these three fields in sync for every desktop version bump:
+
+- `package.json`
+- `apps/tauri/src-tauri/tauri.conf.json`
+- `apps/tauri/src-tauri/Cargo.toml`
+
+Validate with:
+
+```bash
+npm run check:desktop-version
+```
+
+Do not treat `apps/tauri/haven-voice` version as the desktop app version. The
+sidecar is an internal Linux binary with its own package version.
+
+## Release Notes
+
+- The workflow reads `docs/releases/<tag>.md` verbatim.
+- If the file is absent, it falls back to a generic installer/update body.
+- Only publish the sanitized public signoff summary plus human notes.
+- Never copy raw `test-reports/` logs, full signoff markdown, JSON, local paths,
+  or signer-local details into release notes.
+- An empty release note file is worse than absent: the workflow will publish an
+  empty body instead of the safe fallback.
+
+## Required Secrets And Env
+
+- Updater/minisign:
+  - `TAURI_SIGNING_PRIVATE_KEY`
+  - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+- Packaged boot config:
+  - `VITE_SUPABASE_URL`
+  - `VITE_SUPABASE_ANON_KEY`
+- macOS Developer ID signing/notarization:
+  - `APPLE_CERTIFICATE`
+  - `APPLE_CERTIFICATE_PASSWORD`
+  - `APPLE_SIGNING_IDENTITY`
+  - `APPLE_API_KEY_CONTENT`
+  - `APPLE_API_KEY`
+  - `APPLE_API_ISSUER`
+
+Windows Authenticode signing is not wired in this workflow today. Updater
+signing is independent and does not remove SmartScreen prompts.
+
+## Matrix Specifics
+
+- macOS builds universal Apple artifacts with
+  `--target universal-apple-darwin`.
+- Linux installs WebKitGTK/appindicator/rsvg/patchelf and ALSA dev packages.
+- Linux alone builds and stages `haven-voice` before `tauri-action`.
+- Windows does not build or stage the Linux sidecar.
+
+## Validation
+
+- `npm run check:desktop-version`
+- `npm run build:solid`
+- `cargo check --manifest-path apps/tauri/src-tauri/Cargo.toml`
+- `cargo build --locked --manifest-path apps/tauri/haven-voice/Cargo.toml`
+  when Linux sidecar or release Linux dependencies changed
+- `npm run tauri:build` for local packaged smoke when config/release behavior
+  changed
+
+Before publishing a draft release, confirm the draft contains all expected
+platform artifacts and one combined updater manifest.

--- a/docs/architecture/NATIVE_VOICE.md
+++ b/docs/architecture/NATIVE_VOICE.md
@@ -67,6 +67,10 @@ sidecar identities map straight onto the UI's `memberVolumes` / roster.
   gain before the mixer, and uses the mixer's master gain for deafen.
 - **Audio is mono.** Voice is mono; LiveKit downmixes received audio to mono and
   DTX is mono-only. Do not "upgrade" the sidecar to stereo for voice.
+- **Desktop popout is not live yet.** The route/window seam exists, but the
+  launcher is hidden because the current BroadcastChannel mirror does not
+  reliably cross Tauri `WebviewWindow`s. Keep it hidden until voice sync moves
+  to a Tauri-safe event-backed protocol.
 
 ### Known duplication (do not merge yet, just know)
 

--- a/docs/architecture/SOLID_CLIENT_SHAPE.md
+++ b/docs/architecture/SOLID_CLIENT_SHAPE.md
@@ -127,11 +127,13 @@ across windows.
    remote control**: it renders state broadcast by the owning window and sends
    commands (mute/deafen/leave) back. It never opens its own LiveKit
    connection — two connections would mean double audio and double presence.
-2. **Transport is `BroadcastChannel`** (`contexts/voiceSync.ts`). It works
-   identically across browser tabs and same-origin Tauri webviews, so the
-   protocol needs no bridge capability and no shell-specific code. The popout
-   route renders "Not connected" if no owner ever broadcasts.
-3. **Scope:** this is the pattern for *session-owning* surfaces (voice now,
+2. **Transport is currently `BroadcastChannel`** (`contexts/voiceSync.ts`) for
+   browser windows. It does **not** reliably cross Tauri `WebviewWindow`s in
+   the desktop shell, so the desktop voice pop-out launcher is intentionally
+   hidden. Do not re-enable it until sync moves to a Tauri-safe event-backed
+   protocol. The popout route renders "Not connected" if no owner ever
+   broadcasts.
+3. **Scope:** this is the pattern for _session-owning_ surfaces (voice now,
    maybe screen-share later). Read-only data surfaces that popout in the
    future may instead boot their own core and fetch their own data — decide
    per popout, against this record.
@@ -145,7 +147,7 @@ across windows.
    `/popout` branch mounts the lightest shell its surfaces need: a mirror
    surface (voice) gets `PopoutLiteShell` — theme from localStorage and
    nothing else, so a popout window never boots a second session or opens a
-   second realtime subscription. A future *data-backed* popout (e.g. watching
+   second realtime subscription. A future _data-backed_ popout (e.g. watching
    a channel's messages in its own window) registers under `/popout` with its
    own session-equipped shell — the seam is always "add a shell component +
    a child route," never special window code.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "lint": "eslint \"{apps,packages,tooling}/**/*.{js,ts,tsx}\"",
+    "check:agent-skills": "node tooling/scripts/validate-agent-skills.mjs",
     "check:desktop-version": "node tooling/scripts/check-desktop-version-sync.mjs",
     "check:shared-hex": "node tooling/scripts/check-shared-hex-literals.mjs",
     "check:shared-portable": "node tooling/scripts/check-shared-portable.mjs",

--- a/tooling/scripts/check-chat-surface.mjs
+++ b/tooling/scripts/check-chat-surface.mjs
@@ -115,7 +115,7 @@ if (violations.length) {
   console.error(
     "check:chat-surface failed — mobile chat surface violations:\n\n" +
       violations.join("\n") +
-      "\n\nSee .cursor/skills/haven-mobile-chat-surface/SKILL.md\n",
+      "\n\nSee docs/agent-skills/haven-mobile-chat-surface/SKILL.md\n",
   );
   process.exit(1);
 }

--- a/tooling/scripts/validate-agent-skills.mjs
+++ b/tooling/scripts/validate-agent-skills.mjs
@@ -1,0 +1,209 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../..");
+const skillsRoot = path.join(repoRoot, "docs", "agent-skills");
+
+const allowedFrontmatterKeys = new Set(["name", "description"]);
+const skillNameRe = /^[a-z0-9-]{1,63}$/;
+
+const errors = [];
+
+function rel(filePath) {
+  return path.relative(repoRoot, filePath).replace(/\\/g, "/");
+}
+
+function read(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function fail(message) {
+  errors.push(message);
+}
+
+function listSkillDirs() {
+  if (!fs.existsSync(skillsRoot)) {
+    fail(`Missing skills directory: ${rel(skillsRoot)}`);
+    return [];
+  }
+
+  return fs
+    .readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(skillsRoot, entry.name))
+    .sort();
+}
+
+function parseFrontmatter(filePath, text) {
+  if (!text.startsWith("---\n")) {
+    fail(`${rel(filePath)}: missing opening YAML frontmatter fence`);
+    return null;
+  }
+
+  const end = text.indexOf("\n---\n", 4);
+  if (end === -1) {
+    fail(`${rel(filePath)}: missing closing YAML frontmatter fence`);
+    return null;
+  }
+
+  const frontmatter = text.slice(4, end);
+  const body = text.slice(end + "\n---\n".length);
+  const data = {};
+  const seenKeys = new Set();
+  const lines = frontmatter.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i];
+    if (!raw.trim()) continue;
+    if (/^\s/.test(raw)) {
+      fail(`${rel(filePath)}:${i + 1}: unexpected indented frontmatter line`);
+      continue;
+    }
+
+    const match = raw.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/);
+    if (!match) {
+      fail(`${rel(filePath)}:${i + 1}: invalid frontmatter line`);
+      continue;
+    }
+
+    const [, key, rawValue = ""] = match;
+    if (seenKeys.has(key)) {
+      fail(`${rel(filePath)}:${i + 1}: duplicate frontmatter key "${key}"`);
+    }
+    seenKeys.add(key);
+
+    if (!allowedFrontmatterKeys.has(key)) {
+      fail(`${rel(filePath)}:${i + 1}: unsupported frontmatter key "${key}"`);
+    }
+
+    const value = rawValue.trim();
+    if (value === ">" || value === "|") {
+      const block = [];
+      while (
+        i + 1 < lines.length &&
+        (/^\s/.test(lines[i + 1]) || !lines[i + 1].trim())
+      ) {
+        i += 1;
+        block.push(lines[i].replace(/^\s{0,2}/, ""));
+      }
+      data[key] =
+        value === ">"
+          ? block.join(" ").replace(/\s+/g, " ").trim()
+          : block.join("\n").trim();
+    } else {
+      data[key] = stripYamlQuotes(value);
+    }
+  }
+
+  return { data, body };
+}
+
+function stripYamlQuotes(value) {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function validateSkill(skillDir) {
+  const folderName = path.basename(skillDir);
+  const skillFile = path.join(skillDir, "SKILL.md");
+
+  if (!fs.existsSync(skillFile)) {
+    fail(`${rel(skillDir)}: missing SKILL.md`);
+    return null;
+  }
+
+  const parsed = parseFrontmatter(skillFile, read(skillFile));
+  if (!parsed) return skillFile;
+
+  const { data, body } = parsed;
+  const name = data.name;
+  const description = data.description;
+
+  if (!name) {
+    fail(`${rel(skillFile)}: missing required frontmatter key "name"`);
+  } else {
+    if (name !== folderName) {
+      fail(
+        `${rel(skillFile)}: name "${name}" must match folder "${folderName}"`,
+      );
+    }
+    if (!skillNameRe.test(name)) {
+      fail(
+        `${rel(skillFile)}: name "${name}" must be lowercase letters, digits, and hyphens, max 63 chars`,
+      );
+    }
+  }
+
+  if (!description) {
+    fail(`${rel(skillFile)}: missing required frontmatter key "description"`);
+  }
+
+  if (!body.trim()) {
+    fail(`${rel(skillFile)}: missing body content after frontmatter`);
+  }
+
+  return skillFile;
+}
+
+function isExternalLink(target) {
+  return /^[a-z][a-z0-9+.-]*:/i.test(target);
+}
+
+function validateMarkdownLinks(filePath) {
+  const text = read(filePath);
+  const dir = path.dirname(filePath);
+  const linkRe = /(?<!!)\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  let match;
+
+  while ((match = linkRe.exec(text))) {
+    const target = match[1];
+    const withoutAnchor = target.split("#")[0];
+
+    if (!withoutAnchor || isExternalLink(withoutAnchor)) continue;
+
+    const resolved = path.normalize(path.join(dir, decodeURI(withoutAnchor)));
+    if (!fs.existsSync(resolved)) {
+      fail(
+        `${rel(filePath)}: broken relative link "${target}" -> ${rel(resolved)}`,
+      );
+    }
+  }
+}
+
+const skillFiles = [];
+const names = new Set();
+
+for (const skillDir of listSkillDirs()) {
+  const skillFile = validateSkill(skillDir);
+  if (skillFile) {
+    skillFiles.push(skillFile);
+    const name = path.basename(skillDir);
+    if (names.has(name)) fail(`${rel(skillDir)}: duplicate skill folder`);
+    names.add(name);
+  }
+}
+
+for (const filePath of [
+  path.join(repoRoot, "AGENTS.md"),
+  path.join(repoRoot, "docs", "README.md"),
+  ...skillFiles,
+]) {
+  if (fs.existsSync(filePath)) validateMarkdownLinks(filePath);
+}
+
+if (errors.length > 0) {
+  console.error("check:agent-skills failed:\n");
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(`check:agent-skills: OK (${skillFiles.length} skills)`);


### PR DESCRIPTION
## Summary
- Add root `AGENTS.md` as a quick maintainer/agent index for Haven’s mission, core surfaces, footguns, and refactor watchlist.
- Add focused `docs/agent-skills/*/SKILL.md` files for branch/CI discipline, shared core boundaries, Solid client work, mobile surfaces, Supabase/RLS, native voice, and Tauri desktop/release/lockfile hazards.
- Add `npm run check:agent-skills` with a repo-local validator for tracked agent skills and markdown links.
- Update docs around Tauri voice popout/BroadcastChannel behavior and desktop signing status.
- Point `check:chat-surface` at the tracked mobile chat-surface skill instead of the ignored `.cursor` path.

## Validation
- `npm run check:agent-skills`
- `npm run check:chat-surface`
- `npm run check:desktop-version`
- `npm run lint` — passes with 7 existing `react-hooks/exhaustive-deps` warnings, no errors
- `npx prettier --check AGENTS.md docs/README.md docs/architecture/NATIVE_VOICE.md docs/architecture/SOLID_CLIENT_SHAPE.md docs/agent-skills/*/SKILL.md tooling/scripts/validate-agent-skills.mjs tooling/scripts/check-chat-surface.mjs package.json .github/workflows/release-desktop.yml`

## Notes
- This PR targets `staging`, not `main`, matching the current release posture.
- The Python `quick_validate.py` path was not changed; the new validator avoids relying on globally installed PyYAML.